### PR TITLE
feat(cluster): parallelize spawn drain loop with instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "murmer"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "bytes",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "murmer-cluster-tests"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "murmer",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "murmer-examples"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "murmer",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "murmer-macros"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/src/orchestrator.rs
+++ b/examples/src/orchestrator.rs
@@ -573,4 +573,185 @@ mod tests {
         node_a.shutdown().await;
         node_b.shutdown().await;
     }
+
+    // ── Test: Spawn pipeline parallelism ─────────────────────────────────
+
+    /// N concurrent SubmitSpec calls on a node whose factory sleeps should
+    /// complete in roughly factory_time, not N × factory_time.
+    ///
+    /// With the old serial drain loop this test would take ≥ N × FACTORY_SLEEP.
+    /// With parallel dispatch it finishes in ~FACTORY_SLEEP + scheduling jitter.
+    #[tokio::test]
+    async fn test_spawn_pipeline_parallelism() {
+        init_tracing();
+
+        const N: usize = 20;
+        const FACTORY_SLEEP: Duration = Duration::from_millis(200);
+
+        let mut reg = SpawnRegistry::new();
+        reg.register(
+            "orchestrator::SlowActor",
+            Box::new(move |receptionist, label, _state_bytes: Vec<u8>| {
+                Box::pin(async move {
+                    tokio::time::sleep(FACTORY_SLEEP).await;
+                    receptionist.start(&label, StorageAgent, StorageState {
+                        root_name: label.clone(),
+                        dirs: Default::default(),
+                    });
+                    Ok(())
+                })
+            }),
+        );
+
+        let node = System::clustered(
+            node_config("parallel-solo", NodeClass::Worker, vec![], &[]),
+            TypeRegistry::from_auto(),
+            reg,
+        )
+        .await
+        .unwrap();
+
+        let cluster = node.cluster_system().unwrap();
+        let coordinator_ep = bridge::start_coordinator(
+            cluster,
+            CoordinatorState::new(
+                cluster.identity().node_id_string(),
+                Box::new(LeastLoaded),
+                Box::new(OldestNode::any()),
+            ),
+        );
+
+        let dummy_state = bincode::serde::encode_to_vec(
+            &StorageState { root_name: "x".into(), dirs: Default::default() },
+            bincode::config::standard(),
+        )
+        .unwrap();
+
+        let start = tokio::time::Instant::now();
+
+        let mut js = tokio::task::JoinSet::new();
+        for i in 0..N {
+            let ep = coordinator_ep.clone();
+            let state = dummy_state.clone();
+            js.spawn(async move {
+                ep.send(SubmitSpec {
+                    spec: ActorSpec::new(&format!("slow/{i}"), "orchestrator::SlowActor")
+                        .with_state(state)
+                        .with_crash_strategy(CrashStrategy::WaitForReturn(Duration::from_secs(30))),
+                })
+                .await
+                .unwrap()
+            });
+        }
+        while js.join_next().await.is_some() {}
+
+        // Wait for all actors to actually appear (factory ran and registered them).
+        for i in 0..N {
+            wait_for::<StorageAgent>(&node, &format!("slow/{i}")).await;
+        }
+
+        let elapsed = start.elapsed();
+        // Serial would be N × FACTORY_SLEEP. Allow 4× slack for scheduling jitter.
+        let serial_time = FACTORY_SLEEP * N as u32;
+        let limit = FACTORY_SLEEP * 4;
+        assert!(
+            elapsed < limit,
+            "spawn pipeline took {elapsed:?} — expected < {limit:?} (serial would be {serial_time:?})"
+        );
+
+        node.shutdown().await;
+    }
+
+    // ── Test: Panic-safety via AckGuard ──────────────────────────────────
+
+    /// A factory that panics must not leave a stale entry in pending_spawns.
+    /// The AckGuard's Drop impl fires a failure ack, so subsequent spawns
+    /// on the same node must still succeed.
+    #[tokio::test]
+    async fn test_panicking_factory_delivers_failure_ack() {
+        init_tracing();
+
+        let mut reg = SpawnRegistry::new();
+
+        // Panicking factory
+        reg.register(
+            "orchestrator::PanicActor",
+            Box::new(|_receptionist, _label, _state_bytes: Vec<u8>| {
+                Box::pin(async move {
+                    panic!("intentional factory panic for test");
+                    #[allow(unreachable_code)]
+                    Ok(())
+                })
+            }),
+        );
+
+        // Normal factory registered alongside to prove the drain loop survives
+        reg.register(
+            "orchestrator::SlowActor",
+            Box::new(|receptionist, label, _state_bytes: Vec<u8>| {
+                Box::pin(async move {
+                    receptionist.start(&label, StorageAgent, StorageState {
+                        root_name: label.clone(),
+                        dirs: Default::default(),
+                    });
+                    Ok(())
+                })
+            }),
+        );
+
+        let node = System::clustered(
+            node_config("panic-solo", NodeClass::Worker, vec![], &[]),
+            TypeRegistry::from_auto(),
+            reg,
+        )
+        .await
+        .unwrap();
+
+        let cluster = node.cluster_system().unwrap();
+        let coordinator_ep = bridge::start_coordinator(
+            cluster,
+            CoordinatorState::new(
+                cluster.identity().node_id_string(),
+                Box::new(LeastLoaded),
+                Box::new(OldestNode::any()),
+            ),
+        );
+
+        let dummy_state = bincode::serde::encode_to_vec(
+            &StorageState { root_name: "x".into(), dirs: Default::default() },
+            bincode::config::standard(),
+        )
+        .unwrap();
+
+        // Submit a spec whose factory will panic — result should be a placement
+        // decision (SubmitSpec succeeds) but the actor should never appear.
+        let result = coordinator_ep
+            .send(SubmitSpec {
+                spec: ActorSpec::new("panic/0", "orchestrator::PanicActor")
+                    .with_state(dummy_state.clone())
+                    .with_crash_strategy(CrashStrategy::WaitForReturn(Duration::from_secs(5))),
+            })
+            .await
+            .unwrap();
+        assert!(result.is_ok(), "placement decision should succeed: {result:?}");
+
+        // Give the panic task time to fire and the AckGuard drop to deliver the
+        // failure ack back to the Coordinator.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        // Subsequent spawn on the same node must work — drain loop must still be alive.
+        let result2 = coordinator_ep
+            .send(SubmitSpec {
+                spec: ActorSpec::new("after-panic/0", "orchestrator::SlowActor")
+                    .with_state(dummy_state.clone())
+                    .with_crash_strategy(CrashStrategy::WaitForReturn(Duration::from_secs(10))),
+            })
+            .await
+            .unwrap();
+        assert!(result2.is_ok(), "spawn after panic must succeed: {result2:?}");
+
+        wait_for::<StorageAgent>(&node, "after-panic/0").await;
+
+        node.shutdown().await;
+    }
 }

--- a/examples/src/orchestrator.rs
+++ b/examples/src/orchestrator.rs
@@ -642,7 +642,7 @@ mod tests {
             let state = dummy_state.clone();
             js.spawn(async move {
                 ep.send(SubmitSpec {
-                    spec: ActorSpec::new(&format!("slow/{i}"), "orchestrator::SlowActor")
+                    spec: ActorSpec::new(format!("slow/{i}"), "orchestrator::SlowActor")
                         .with_state(state)
                         .with_crash_strategy(CrashStrategy::WaitForReturn(Duration::from_secs(30))),
                 })

--- a/examples/src/orchestrator.rs
+++ b/examples/src/orchestrator.rs
@@ -594,10 +594,14 @@ mod tests {
             Box::new(move |receptionist, label, _state_bytes: Vec<u8>| {
                 Box::pin(async move {
                     tokio::time::sleep(FACTORY_SLEEP).await;
-                    receptionist.start(&label, StorageAgent, StorageState {
-                        root_name: label.clone(),
-                        dirs: Default::default(),
-                    });
+                    receptionist.start(
+                        &label,
+                        StorageAgent,
+                        StorageState {
+                            root_name: label.clone(),
+                            dirs: Default::default(),
+                        },
+                    );
                     Ok(())
                 })
             }),
@@ -622,7 +626,10 @@ mod tests {
         );
 
         let dummy_state = bincode::serde::encode_to_vec(
-            &StorageState { root_name: "x".into(), dirs: Default::default() },
+            &StorageState {
+                root_name: "x".into(),
+                dirs: Default::default(),
+            },
             bincode::config::standard(),
         )
         .unwrap();
@@ -690,10 +697,14 @@ mod tests {
             "orchestrator::SlowActor",
             Box::new(|receptionist, label, _state_bytes: Vec<u8>| {
                 Box::pin(async move {
-                    receptionist.start(&label, StorageAgent, StorageState {
-                        root_name: label.clone(),
-                        dirs: Default::default(),
-                    });
+                    receptionist.start(
+                        &label,
+                        StorageAgent,
+                        StorageState {
+                            root_name: label.clone(),
+                            dirs: Default::default(),
+                        },
+                    );
                     Ok(())
                 })
             }),
@@ -718,7 +729,10 @@ mod tests {
         );
 
         let dummy_state = bincode::serde::encode_to_vec(
-            &StorageState { root_name: "x".into(), dirs: Default::default() },
+            &StorageState {
+                root_name: "x".into(),
+                dirs: Default::default(),
+            },
             bincode::config::standard(),
         )
         .unwrap();
@@ -733,7 +747,10 @@ mod tests {
             })
             .await
             .unwrap();
-        assert!(result.is_ok(), "placement decision should succeed: {result:?}");
+        assert!(
+            result.is_ok(),
+            "placement decision should succeed: {result:?}"
+        );
 
         // Give the panic task time to fire and the AckGuard drop to deliver the
         // failure ack back to the Coordinator.
@@ -748,7 +765,10 @@ mod tests {
             })
             .await
             .unwrap();
-        assert!(result2.is_ok(), "spawn after panic must succeed: {result2:?}");
+        assert!(
+            result2.is_ok(),
+            "spawn after panic must succeed: {result2:?}"
+        );
 
         wait_for::<StorageAgent>(&node, "after-panic/0").await;
 

--- a/murmer/src/app/bridge.rs
+++ b/murmer/src/app/bridge.rs
@@ -194,7 +194,11 @@ struct AckGuard {
 
 impl AckGuard {
     fn new(coordinator: Endpoint<Coordinator>, request_id: u64) -> Self {
-        Self { coordinator, request_id, sent: false }
+        Self {
+            coordinator,
+            request_id,
+            sent: false,
+        }
     }
 
     fn ack(mut self, success: bool, error: Option<String>) {
@@ -202,7 +206,13 @@ impl AckGuard {
         let coord = self.coordinator.clone();
         let id = self.request_id;
         tokio::spawn(async move {
-            let _ = coord.send(NotifySpawnAck { request_id: id, success, error }).await;
+            let _ = coord
+                .send(NotifySpawnAck {
+                    request_id: id,
+                    success,
+                    error,
+                })
+                .await;
         });
     }
 }
@@ -251,7 +261,9 @@ async fn run_spawn_drain_loop(
     queue_depth: Arc<AtomicUsize>,
 ) {
     while let Some((node_id, request, enqueued_at)) = rx.recv().await {
-        let depth = queue_depth.fetch_sub(1, Ordering::Relaxed).saturating_sub(1);
+        let depth = queue_depth
+            .fetch_sub(1, Ordering::Relaxed)
+            .saturating_sub(1);
         crate::instrument::spawn_drain_queue_depth(depth as f64);
         crate::instrument::spawn_drain_dispatch(enqueued_at.elapsed());
 

--- a/murmer/src/app/bridge.rs
+++ b/murmer/src/app/bridge.rs
@@ -16,6 +16,7 @@
 //! ```
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::cluster::ClusterSystem;
 use crate::cluster::framing::ControlMessage;
@@ -59,8 +60,9 @@ pub fn start_coordinator(
     );
     state.cluster_view.upsert_node(local_info);
 
+    let queue_depth = Arc::new(AtomicUsize::new(0));
     let (spawn_tx, spawn_rx) = mpsc::unbounded_channel();
-    let state = state.with_spawn_sender(SpawnSender::new(spawn_tx));
+    let state = state.with_spawn_sender(SpawnSender::new(spawn_tx, Arc::clone(&queue_depth)));
 
     let coordinator_ep = cluster.start_actor("coordinator", Coordinator, state);
 
@@ -85,6 +87,7 @@ pub fn start_coordinator(
         receptionist,
         ack_ep,
         spawn_rx,
+        queue_depth,
     ));
 
     coordinator_ep
@@ -177,51 +180,123 @@ async fn run_bridge_loop(
     }
 }
 
-/// Drain loop: reads spawn requests from the channel and either spawns locally
-/// (if target == local node) or sends a `SpawnActor` control message via transport.
+/// RAII guard that guarantees a `NotifySpawnAck` is always delivered.
+///
+/// On the happy path call `ack(success, error)` to consume the guard and send
+/// the ack. If the task holding the guard panics or is cancelled before
+/// reaching `ack`, `Drop` fires a detached task to send a failure ack so
+/// `pending_spawns` in the Coordinator never leaks a stale entry.
+struct AckGuard {
+    coordinator: Endpoint<Coordinator>,
+    request_id: u64,
+    sent: bool,
+}
+
+impl AckGuard {
+    fn new(coordinator: Endpoint<Coordinator>, request_id: u64) -> Self {
+        Self { coordinator, request_id, sent: false }
+    }
+
+    fn ack(mut self, success: bool, error: Option<String>) {
+        self.sent = true;
+        let coord = self.coordinator.clone();
+        let id = self.request_id;
+        tokio::spawn(async move {
+            let _ = coord.send(NotifySpawnAck { request_id: id, success, error }).await;
+        });
+    }
+}
+
+impl Drop for AckGuard {
+    fn drop(&mut self) {
+        if self.sent {
+            return;
+        }
+        // Guard against dropping after the tokio runtime has shut down.
+        if tokio::runtime::Handle::try_current().is_err() {
+            return;
+        }
+        let coord = self.coordinator.clone();
+        let id = self.request_id;
+        tokio::spawn(async move {
+            let _ = coord
+                .send(NotifySpawnAck {
+                    request_id: id,
+                    success: false,
+                    error: Some("spawn task panicked or was cancelled".into()),
+                })
+                .await;
+        });
+    }
+}
+
+/// Drain loop: reads spawn requests from the channel and dispatches each one
+/// as an independent `tokio::spawn` task so factories run concurrently.
+///
+/// Requests are dequeued in receive order but execute concurrently — acks may
+/// arrive at the Coordinator in any order (which is fine: `notify_spawn_ack`
+/// keys on `request_id`). A panicking or cancelled factory task delivers a
+/// failure ack via `AckGuard::drop` so `pending_spawns` always converges.
+///
+/// Fan-out is naturally bounded by the upstream admission control on the
+/// caller's side (e.g. the supervisor semaphore in datastorekit). Murmer does
+/// not impose its own cap.
 async fn run_spawn_drain_loop(
     transport: Arc<Transport>,
     local_node_id: String,
     spawn_registry: Arc<crate::cluster::sync::SpawnRegistry>,
     receptionist: crate::receptionist::Receptionist,
     coordinator: Endpoint<Coordinator>,
-    mut rx: mpsc::UnboundedReceiver<(String, crate::cluster::framing::SpawnRequest)>,
+    mut rx: mpsc::UnboundedReceiver<crate::app::spawn_sender::SpawnItem>,
+    queue_depth: Arc<AtomicUsize>,
 ) {
-    while let Some((node_id, request)) = rx.recv().await {
+    while let Some((node_id, request, enqueued_at)) = rx.recv().await {
+        let depth = queue_depth.fetch_sub(1, Ordering::Relaxed).saturating_sub(1);
+        crate::instrument::spawn_drain_queue_depth(depth as f64);
+        crate::instrument::spawn_drain_dispatch(enqueued_at.elapsed());
+
         if node_id == local_node_id {
-            // Local spawn — bypass transport, invoke spawn registry directly
             tracing::debug!(
                 "Spawning actor locally: label={}, type={}",
                 request.label,
                 request.actor_type_name
             );
-            let result = spawn_registry
-                .spawn(
-                    receptionist.clone(),
-                    &request.label,
-                    &request.actor_type_name,
-                    &request.initial_state,
-                )
-                .await;
-            let _ = coordinator
-                .send(NotifySpawnAck {
-                    request_id: request.request_id,
-                    success: result.is_ok(),
-                    error: result.err().map(|e| e.to_string()),
-                })
-                .await;
+            let registry = Arc::clone(&spawn_registry);
+            let receptionist = receptionist.clone();
+            let guard = AckGuard::new(coordinator.clone(), request.request_id);
+            tokio::spawn(async move {
+                let factory_start = std::time::Instant::now();
+                let result = registry
+                    .spawn(
+                        receptionist,
+                        &request.label,
+                        &request.actor_type_name,
+                        &request.initial_state,
+                    )
+                    .await;
+                crate::instrument::spawn_drain_factory("local", factory_start.elapsed());
+                match result {
+                    Ok(()) => guard.ack(true, None),
+                    Err(e) => guard.ack(false, Some(e.to_string())),
+                }
+            });
         } else {
             tracing::debug!(
                 "Sending SpawnActor to {node_id}: label={}, type={}",
                 request.label,
                 request.actor_type_name
             );
-            if let Err(e) = transport
-                .send_control(&node_id, ControlMessage::SpawnActor(request))
-                .await
-            {
-                tracing::warn!("Failed to send spawn request to {node_id}: {e}");
-            }
+            let transport = Arc::clone(&transport);
+            tokio::spawn(async move {
+                let factory_start = std::time::Instant::now();
+                if let Err(e) = transport
+                    .send_control(&node_id, ControlMessage::SpawnActor(request))
+                    .await
+                {
+                    tracing::warn!("Failed to send spawn request to {node_id}: {e}");
+                }
+                crate::instrument::spawn_drain_factory("remote", factory_start.elapsed());
+            });
         }
     }
 }

--- a/murmer/src/app/spawn_sender.rs
+++ b/murmer/src/app/spawn_sender.rs
@@ -4,8 +4,8 @@
 //! `(node_id, SpawnRequest, enqueue_time)` tuples into it, and the bridge drain
 //! loop translates them into `transport.send_control()` calls or local spawns.
 
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 
 use crate::cluster::framing::SpawnRequest;
@@ -29,7 +29,11 @@ impl SpawnSender {
     /// Queue a spawn request for the given target node.
     pub fn send_spawn(&self, target_node_id: &str, request: SpawnRequest) {
         self.queue_depth.fetch_add(1, Ordering::Relaxed);
-        if self.tx.send((target_node_id.to_string(), request, Instant::now())).is_err() {
+        if self
+            .tx
+            .send((target_node_id.to_string(), request, Instant::now()))
+            .is_err()
+        {
             self.queue_depth.fetch_sub(1, Ordering::Relaxed);
             tracing::warn!("Spawn sender channel closed — spawn request dropped");
         }

--- a/murmer/src/app/spawn_sender.rs
+++ b/murmer/src/app/spawn_sender.rs
@@ -1,27 +1,36 @@
 //! Internal channel for the Coordinator to request remote spawns.
 //!
 //! The [`SpawnSender`] wraps an unbounded channel. The Coordinator pushes
-//! `(node_id, SpawnRequest)` pairs into it, and the bridge drain loop
-//! translates them into `transport.send_control()` calls.
+//! `(node_id, SpawnRequest, enqueue_time)` tuples into it, and the bridge drain
+//! loop translates them into `transport.send_control()` calls or local spawns.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
 
 use crate::cluster::framing::SpawnRequest;
 use tokio::sync::mpsc;
+
+pub(crate) type SpawnItem = (String, SpawnRequest, Instant);
 
 /// A channel-based handle the Coordinator uses to request remote spawns.
 ///
 /// Not public — created internally by [`crate::app::bridge::start_coordinator`].
 pub(crate) struct SpawnSender {
-    tx: mpsc::UnboundedSender<(String, SpawnRequest)>,
+    tx: mpsc::UnboundedSender<SpawnItem>,
+    queue_depth: Arc<AtomicUsize>,
 }
 
 impl SpawnSender {
-    pub fn new(tx: mpsc::UnboundedSender<(String, SpawnRequest)>) -> Self {
-        Self { tx }
+    pub fn new(tx: mpsc::UnboundedSender<SpawnItem>, queue_depth: Arc<AtomicUsize>) -> Self {
+        Self { tx, queue_depth }
     }
 
     /// Queue a spawn request for the given target node.
     pub fn send_spawn(&self, target_node_id: &str, request: SpawnRequest) {
-        if self.tx.send((target_node_id.to_string(), request)).is_err() {
+        self.queue_depth.fetch_add(1, Ordering::Relaxed);
+        if self.tx.send((target_node_id.to_string(), request, Instant::now())).is_err() {
+            self.queue_depth.fetch_sub(1, Ordering::Relaxed);
             tracing::warn!("Spawn sender channel closed — spawn request dropped");
         }
     }

--- a/murmer/src/instrument.rs
+++ b/murmer/src/instrument.rs
@@ -255,6 +255,36 @@ pub(crate) fn cluster_node_left() {
     }
 }
 
+// ─── Spawn Drain Loop ────────────────────────────────────────────────
+
+#[inline(always)]
+pub(crate) fn spawn_drain_dispatch(duration: std::time::Duration) {
+    #[cfg(feature = "monitor")]
+    metrics::histogram!("murmer_spawn_drain_dispatch_seconds").record(duration);
+    #[cfg(not(feature = "monitor"))]
+    let _ = duration;
+}
+
+#[inline(always)]
+pub(crate) fn spawn_drain_factory(locality: &str, duration: std::time::Duration) {
+    #[cfg(feature = "monitor")]
+    metrics::histogram!(
+        "murmer_spawn_drain_factory_seconds",
+        "locality" => locality.to_string(),
+    )
+    .record(duration);
+    #[cfg(not(feature = "monitor"))]
+    let _ = (locality, duration);
+}
+
+#[inline(always)]
+pub(crate) fn spawn_drain_queue_depth(depth: f64) {
+    #[cfg(feature = "monitor")]
+    metrics::gauge!("murmer_spawn_drain_queue_depth").set(depth);
+    #[cfg(not(feature = "monitor"))]
+    let _ = depth;
+}
+
 // ─── Receptionist ────────────────────────────────────────────────────
 
 #[inline(always)]

--- a/murmer/src/monitor/prometheus_setup.rs
+++ b/murmer/src/monitor/prometheus_setup.rs
@@ -138,6 +138,20 @@ fn describe_metrics() {
         "Total number of cluster membership change events"
     );
 
+    // Spawn drain loop
+    metrics::describe_histogram!(
+        "murmer_spawn_drain_dispatch_seconds",
+        "Time from SpawnSender::send_spawn enqueue to drain-loop pop (dispatch latency)"
+    );
+    metrics::describe_histogram!(
+        "murmer_spawn_drain_factory_seconds",
+        "Wall-clock time for a spawn factory (local) or send_control (remote) to complete",
+    );
+    metrics::describe_gauge!(
+        "murmer_spawn_drain_queue_depth",
+        "Number of spawn requests currently pending in the drain-loop channel"
+    );
+
     // Receptionist
     metrics::describe_counter!(
         "murmer_receptionist_lookups_total",


### PR DESCRIPTION
## Summary
- **Parallelize spawn drain loop**: Replace serial `spawn_registry.spawn().await` with `tokio::spawn` per request so factories on a node execute concurrently. An `AckGuard` RAII type ensures `pending_spawns` always converges — on panic or cancellation, `Drop` fires a detached task that delivers a failure ack so no entry is silently leaked.
- **Add spawn drain loop instrumentation** (behind `monitor` feature flag): dispatch latency, factory wall-clock duration (labeled local|remote), and queue depth metrics via Prometheus.
- **New integration tests**: verify 20×200ms factories complete in ~200ms (parallel execution) and that a panicking factory delivers a failure ack without blocking subsequent spawns.

## Test plan
- [x] `cargo nextest run` — existing tests pass
- [x] `test_spawn_pipeline_parallelism` — 20 concurrent 200ms factories complete in ~200ms
- [x] `test_panicking_factory_delivers_failure_ack` — panic delivers failure ack, drain loop continues
- [ ] Manual verification of Prometheus metrics with `monitor` feature enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)