### PR TITLE
feat: cluster singletons + hard placement constraints (fenced single-owner failover & graceful handoff)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +713,7 @@ dependencies = [
 name = "murmer"
 version = "0.2.1"
 dependencies = [
+ "async-trait",
  "bincode",
  "bytes",
  "foca",

--- a/book/src/monitoring.md
+++ b/book/src/monitoring.md
@@ -8,7 +8,7 @@ Add the `monitor` feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-murmer = { version = "0.1", features = ["monitor"] }
+murmer = { version = "0.2", features = ["monitor"] }
 ```
 
 When the feature is **off**, all instrumentation compiles to nothing — zero overhead, zero dependencies.

--- a/book/src/murmer-app.md
+++ b/book/src/murmer-app.md
@@ -8,7 +8,7 @@ Enable the feature in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-murmer = { version = "0.1", features = ["app"] }
+murmer = { version = "0.2", features = ["app"] }
 ```
 
 ## Overview
@@ -68,14 +68,20 @@ Constraints filter eligible nodes *before* the placement strategy scores them:
 PlacementConstraints {
     required_classes: vec![NodeClass::Worker],        // must be a Worker node
     required_metadata: [("gpu".into(), "true".into())].into(), // must have gpu=true
-    anti_affinity_labels: vec!["db/primary".into()],  // don't co-locate with this actor
+    anti_affinity_labels: vec!["db/primary".into()],  // repel: don't co-locate with this actor
+    colocate_with: Some("writer/c1".into()),          // attract: only where "writer/c1" already runs
+    required_node_id: None,                            // or hard-pin to exactly one node id
     ..Default::default()
 }
 ```
 
 - `required_classes` — empty means any class is acceptable.
 - `required_metadata` — the node must have all specified key-value pairs.
-- `anti_affinity_labels` — avoid placing on nodes already running these actors.
+- `anti_affinity_labels` — avoid placing on nodes already running these actors (*repel*).
+- `colocate_with` — place **only** on a node already running the named anchor actor (*attract* — the inverse of anti-affinity). Use it to pin a member next to a partner (e.g. a reader next to its writer). Because it is a hard filter, if no node runs the anchor the spec gets `NoEligibleNodes` rather than landing elsewhere.
+- `required_node_id` — hard-pin to exactly one node id; if that node is not alive the spec gets `NoEligibleNodes` (it is *never* silently relocated — unlike the soft `Pinned` strategy).
+
+> `colocate_with` and `required_node_id` are **hard filters**, not preferences — they are how you build co-located actor groups and node-pinned placement on top of the Coordinator.
 
 ## Placement strategies
 
@@ -187,6 +193,70 @@ Each node in the view carries:
 - **Metadata** — arbitrary key-value pairs (e.g., `"volume" = "photos"`)
 - **Running actors** — labels of actors currently hosted
 - **Liveness** — whether the node is reachable
+
+## Cluster singletons
+
+Some actors must have **exactly one** instance across the whole cluster — a catalog owner, a sequence minter, a lock manager. A *cluster singleton* is a Coordinator-managed actor pinned to an **anchor**, with a **fenced** handoff so two instances never run at once.
+
+```rust,ignore
+use murmer::app::singleton::{SingletonSpec, SingletonAnchor};
+use murmer::app::coordinator::{StartSingleton, GetSingleton};
+
+// Declare the singleton via the Coordinator.
+let ownership = coordinator.send_async(StartSingleton {
+    spec: SingletonSpec::new("catalog", "app::Catalog", SingletonAnchor::Leader)
+        .with_state(boot_bytes),
+}).await??;
+assert_eq!(ownership.generation.term, 1);
+```
+
+Or, as a convenience when the Coordinator is registered under the well-known `"coordinator"` label:
+
+```rust,ignore
+let ownership = system.start_singleton(
+    SingletonSpec::new("catalog", "app::Catalog", SingletonAnchor::Leader),
+).await?;
+```
+
+### Anchors
+
+`SingletonAnchor` decides which node owns the instance:
+
+| Anchor | Owner |
+|--------|-------|
+| `Leader` | Whatever the `LeaderElection` currently elects |
+| `Class(NodeClass)` | The oldest alive node of that class |
+| `Node(node_id)` | Exactly that node (no owner if it is down) |
+
+### The generation fence
+
+Every ownership grant carries a monotone `SingletonGeneration { term, seq }`:
+
+- `term` bumps **once per ownership change** (a failover or move) — an FDB-style recovery epoch.
+- `seq` bumps on a re-grant to the *same* owner (liveness renew / idempotent re-assert).
+
+`SingletonGeneration` orders lexicographically (term-major) and packs into a single `u64` via `packed()` — so a downstream fence that compares one integer (e.g. a write generation stamped on disk) rejects a stale ex-owner **with no change to that comparison**. A node that loses ownership and later returns necessarily holds a strictly-lower generation than its successor, so its first fenced write is rejected.
+
+### Failover
+
+When the owner node leaves or fails, the Coordinator re-places the singleton on a surviving node that still satisfies the anchor, minting a **strictly-higher `term`**. The old owner is gone, so there is no drain — the generation fence is what guarantees a zombie ex-owner cannot double-write:
+
+```rust,ignore
+// Owner departs → the Coordinator re-drives to a survivor with term N+1.
+let after = coordinator.send(GetSingleton { label: "catalog".into() }).await?.unwrap();
+assert!(after.generation > before.generation); // strictly higher — the fence
+```
+
+### Pluggable generation source
+
+By default the Coordinator mints generations in memory (`CoordinatorGenerationSource`), which is fine for a single node or tests but is **not durable across a Coordinator restart**. Inject a durable `GenerationSource` so the generation survives failover of the Coordinator itself:
+
+```rust,ignore
+let state = CoordinatorState::new(local_id, Box::new(LeastLoaded), Box::new(OldestNode::any()))
+    .with_generation_source(Arc::new(MyDurableGenerationSource::new()));
+```
+
+`GenerationSource` has three methods — `claim_term` (begin a new ownership epoch), `claim_seq` (re-grant within the current term), and `current` (read the authoritative ownership for cold-start rebuild after a Coordinator restart). Backing it with an external linearizable store (a database row, a consensus log) is what makes the singleton's identity the single source of truth across the whole cluster.
 
 ## Full example: Filesystem RPC
 

--- a/murmer-cluster-tests/Cargo.toml
+++ b/murmer-cluster-tests/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-murmer = { workspace = true }
+murmer = { workspace = true, features = ["app"] }
 serde = { workspace = true }
 bincode = { workspace = true }
 tokio = { workspace = true }

--- a/murmer-cluster-tests/src/actors.rs
+++ b/murmer-cluster-tests/src/actors.rs
@@ -196,3 +196,49 @@ impl ChatRoom {
             .collect()
     }
 }
+
+// =============================================================================
+// CatalogLike — a spawnable, MigratableActor-style actor for singleton tests
+// =============================================================================
+//
+// Stands in for appdata's CatalogActor: a stateful actor the Coordinator spawns
+// (via a SpawnRegistry) as a cluster singleton, and that clients can reach to
+// prove the singleton is actually running on its owner node.
+
+#[derive(Debug)]
+pub struct CatalogLike;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatalogState {
+    /// A stable name carried in the boot state, echoed back by `Whoami`.
+    pub name: String,
+}
+
+impl Actor for CatalogLike {
+    type State = CatalogState;
+}
+
+/// Ask the catalog singleton to identify itself (proves it is reachable).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Whoami;
+
+impl Message for Whoami {
+    type Result = String;
+}
+
+impl RemoteMessage for Whoami {
+    const TYPE_ID: &'static str = "cluster_test::Whoami";
+}
+
+#[handlers]
+impl CatalogLike {
+    #[handler]
+    fn whoami(
+        &mut self,
+        _ctx: &ActorContext<Self>,
+        state: &mut CatalogState,
+        _msg: Whoami,
+    ) -> String {
+        state.name.clone()
+    }
+}

--- a/murmer-cluster-tests/tests/singleton.rs
+++ b/murmer-cluster-tests/tests/singleton.rs
@@ -1,0 +1,322 @@
+//! Cluster singleton (C-prime M4) integration scenarios over real transport.
+//!
+//! Proves the ClusterSingleton primitive end-to-end through a real `System` +
+//! Coordinator + SpawnRegistry (not the in-process unit harness):
+//!
+//! 1. `start_singleton` places + spawns exactly one instance on its anchor and
+//!    promotes it to `Active` once the spawn ack lands; the instance is reachable.
+//! 2. When the owner node departs, the singleton fails over to a survivor with a
+//!    strictly-higher `term` — the fence that rejects a zombie ex-owner.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use murmer::System;
+use murmer::app::bridge;
+use murmer::app::coordinator::{
+    Coordinator, CoordinatorState, GetSingleton, NotifyNodeJoined, SerializableNodeInfo,
+    StartSingleton,
+};
+use murmer::app::election::OldestNode;
+use murmer::app::placement::LeastLoaded;
+use murmer::app::singleton::{SingletonAnchor, SingletonOwnership, SingletonPhase, SingletonSpec};
+use murmer::cluster::config::{ClusterConfigBuilder, Discovery, NodeClass, NodeIdentity};
+use murmer::cluster::sync::{SpawnRegistry, TypeRegistry};
+use murmer::prelude::*;
+
+use murmer_cluster_tests::actors::{CatalogLike, CatalogState, Whoami};
+
+fn init() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
+}
+
+/// Build a cluster config for a named node with a class and optional seeds.
+fn node_config(
+    name: &str,
+    class: NodeClass,
+    seeds: &[SocketAddr],
+) -> murmer::cluster::config::ClusterConfig {
+    let mut builder = ClusterConfigBuilder::new()
+        .name(name)
+        .listen("127.0.0.1:0".parse::<SocketAddr>().unwrap())
+        .cookie("singleton-test")
+        .discovery(Discovery::None)
+        .node_class(class);
+    if !seeds.is_empty() {
+        builder = builder.seed_nodes(seeds.to_vec());
+    }
+    builder.build().unwrap()
+}
+
+/// A SpawnRegistry that can spawn the `CatalogLike` singleton actor.
+fn catalog_registry() -> SpawnRegistry {
+    let mut reg = SpawnRegistry::new();
+    reg.register(
+        "cluster_test::CatalogLike",
+        Box::new(|receptionist, label, state_bytes: Vec<u8>| {
+            Box::pin(async move {
+                let (state, _): (CatalogState, _) =
+                    bincode::serde::decode_from_slice(&state_bytes, bincode::config::standard())
+                        .map_err(|e| {
+                            murmer::cluster::sync::SpawnError::DeserializeFailed(e.to_string())
+                        })?;
+                receptionist.start(&label, CatalogLike, state);
+                Ok(())
+            })
+        }),
+    );
+    reg
+}
+
+fn catalog_state_bytes(name: &str) -> Vec<u8> {
+    bincode::serde::encode_to_vec(
+        &CatalogState { name: name.into() },
+        bincode::config::standard(),
+    )
+    .unwrap()
+}
+
+/// Poll until an actor is discoverable from a node.
+async fn wait_for<A: Actor + 'static>(
+    system: &System,
+    label: &str,
+    timeout: Duration,
+) -> Endpoint<A> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if let Some(ep) = system.lookup::<A>(label) {
+            return ep;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("timed out waiting for actor {label}");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// Poll `GetSingleton` until the singleton reaches `Active`.
+async fn wait_for_singleton_active(
+    coord: &Endpoint<Coordinator>,
+    label: &str,
+    timeout: Duration,
+) -> SingletonOwnership {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if let Some(own) = coord
+            .send(GetSingleton {
+                label: label.into(),
+            })
+            .await
+            .unwrap()
+            && own.phase == SingletonPhase::Active
+        {
+            return own;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("timed out waiting for singleton {label} to become Active");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// Poll `GetSingleton` until the singleton's term reaches at least `want_term`.
+async fn wait_for_singleton_term(
+    coord: &Endpoint<Coordinator>,
+    label: &str,
+    want_term: u64,
+    timeout: Duration,
+) -> SingletonOwnership {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if let Some(own) = coord
+            .send(GetSingleton {
+                label: label.into(),
+            })
+            .await
+            .unwrap()
+            && own.generation.term >= want_term
+        {
+            return own;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("timed out waiting for singleton {label} to reach term {want_term}");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+async fn notify_joined(
+    coord: &Endpoint<Coordinator>,
+    identity: &NodeIdentity,
+    name: &str,
+    class: NodeClass,
+) {
+    coord
+        .send(NotifyNodeJoined {
+            node_id: identity.node_id_string(),
+            info: SerializableNodeInfo {
+                name: name.into(),
+                host: identity.host.clone(),
+                port: identity.port,
+                incarnation: identity.incarnation,
+                class,
+                metadata: HashMap::new(),
+            },
+        })
+        .await
+        .unwrap();
+}
+
+// ── Test 1: single-node real spawn + Active + reachable ─────────────────────
+
+#[tokio::test]
+async fn test_singleton_starts_and_runs_on_single_node() {
+    init();
+
+    let node = System::clustered(
+        node_config("solo", NodeClass::Worker, &[]),
+        TypeRegistry::from_auto(),
+        catalog_registry(),
+    )
+    .await
+    .unwrap();
+
+    let cluster = node.cluster_system().unwrap();
+    let coord_ep = bridge::start_coordinator(
+        cluster,
+        CoordinatorState::new(
+            cluster.identity().node_id_string(),
+            Box::new(LeastLoaded),
+            Box::new(OldestNode::any()),
+        ),
+    );
+
+    let ownership = coord_ep
+        .send_async(StartSingleton {
+            spec: SingletonSpec::new(
+                "catalog",
+                "cluster_test::CatalogLike",
+                SingletonAnchor::Leader,
+            )
+            .with_state(catalog_state_bytes("catalog-0")),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(ownership.generation.term, 1);
+    assert_eq!(ownership.generation.seq, 0);
+
+    // The catalog actor really spawns via the registry and answers messages.
+    let ep: Endpoint<CatalogLike> = wait_for(&node, "catalog", Duration::from_secs(10)).await;
+    assert_eq!(ep.send(Whoami).await.unwrap(), "catalog-0");
+
+    // Ownership flips to Active once the spawn ack is observed.
+    let active = wait_for_singleton_active(&coord_ep, "catalog", Duration::from_secs(10)).await;
+    assert_eq!(active.phase, SingletonPhase::Active);
+    assert!(active.owner_node_id.unwrap().contains("solo"));
+
+    node.shutdown().await;
+}
+
+// ── Test 2: failover to a survivor with a strictly-higher term ──────────────
+
+#[tokio::test]
+async fn test_singleton_fails_over_on_owner_departure_with_higher_term() {
+    init();
+
+    // Gateway (Edge) hosts the Coordinator; two workers can host the catalog.
+    let gateway = System::clustered(
+        node_config("gateway", NodeClass::Edge, &[]),
+        TypeRegistry::from_auto(),
+        SpawnRegistry::new(),
+    )
+    .await
+    .unwrap();
+    let gw_addr = gateway.local_addr().unwrap();
+
+    let worker_a = System::clustered(
+        node_config("worker-a", NodeClass::Worker, &[gw_addr]),
+        TypeRegistry::from_auto(),
+        catalog_registry(),
+    )
+    .await
+    .unwrap();
+    let worker_b = System::clustered(
+        node_config("worker-b", NodeClass::Worker, &[gw_addr]),
+        TypeRegistry::from_auto(),
+        catalog_registry(),
+    )
+    .await
+    .unwrap();
+
+    // Let the cluster mesh.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let cluster = gateway.cluster_system().unwrap();
+    let coord_ep = bridge::start_coordinator(
+        cluster,
+        CoordinatorState::new(
+            cluster.identity().node_id_string(),
+            Box::new(LeastLoaded),
+            Box::new(OldestNode::with_class(NodeClass::Edge)),
+        ),
+    );
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Seed the Coordinator's view (nodes joined before it started).
+    let a_id = worker_a.cluster_system().unwrap().identity().clone();
+    let b_id = worker_b.cluster_system().unwrap().identity().clone();
+    notify_joined(&coord_ep, cluster.identity(), "gateway", NodeClass::Edge).await;
+    notify_joined(&coord_ep, &a_id, "worker-a", NodeClass::Worker).await;
+    notify_joined(&coord_ep, &b_id, "worker-b", NodeClass::Worker).await;
+
+    // Anchor to the Worker class so the catalog runs on a worker, not the gateway.
+    let first = coord_ep
+        .send_async(StartSingleton {
+            spec: SingletonSpec::new(
+                "catalog",
+                "cluster_test::CatalogLike",
+                SingletonAnchor::Class(NodeClass::Worker),
+            )
+            .with_state(catalog_state_bytes("catalog-0")),
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(first.generation.term, 1);
+    let first_owner = first.owner_node_id.clone().unwrap();
+    assert!(
+        first_owner.contains("worker-a") || first_owner.contains("worker-b"),
+        "owner should be a worker, got {first_owner}"
+    );
+    wait_for_singleton_active(&coord_ep, "catalog", Duration::from_secs(10)).await;
+
+    // Gracefully shut down the owner worker → NodeLeft → fenced re-drive.
+    if first_owner.contains("worker-a") {
+        worker_a.shutdown().await;
+    } else {
+        worker_b.shutdown().await;
+    }
+
+    // The Coordinator re-drives to the survivor with a strictly-higher term.
+    let after = wait_for_singleton_term(&coord_ep, "catalog", 2, Duration::from_secs(15)).await;
+    assert_eq!(after.generation.term, 2);
+    assert!(
+        after.generation > first.generation,
+        "term must strictly increase across failover (the fence)"
+    );
+    assert_ne!(
+        after.owner_node_id.as_deref(),
+        Some(first_owner.as_str()),
+        "singleton must move off the departed owner"
+    );
+
+    gateway.shutdown().await;
+    if first_owner.contains("worker-a") {
+        worker_b.shutdown().await;
+    } else {
+        worker_a.shutdown().await;
+    }
+}

--- a/murmer/Cargo.toml
+++ b/murmer/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["asynchronous", "network-programming", "concurrency"]
 [features]
 default = ["macros"]
 macros = ["dep:murmer-macros"]
-app = []
+app = ["dep:async-trait"]
 monitor = ["dep:metrics", "dep:metrics-exporter-prometheus"]
 
 [dependencies]
@@ -41,6 +41,7 @@ tokio-util = { version = "0.7", features = ["full"] }
 linkme = "0.3"
 metrics = { workspace = true, optional = true }
 metrics-exporter-prometheus = { workspace = true, optional = true }
+async-trait = { version = "0.1", optional = true }
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true }

--- a/murmer/src/app/bridge.rs
+++ b/murmer/src/app/bridge.rs
@@ -134,15 +134,16 @@ async fn run_bridge_loop(
                         .await;
                 }
                 ClusterEvent::NodeFailed(identity) => {
+                    // async handler (re-drives owned singletons) — use send_async.
                     let _ = coordinator
-                        .send(NotifyNodeFailed {
+                        .send_async(NotifyNodeFailed {
                             node_id: identity.node_id_string(),
                         })
                         .await;
                 }
                 ClusterEvent::NodeLeft(identity) => {
                     let _ = coordinator
-                        .send(NotifyNodeLeft {
+                        .send_async(NotifyNodeLeft {
                             node_id: identity.node_id_string(),
                         })
                         .await;

--- a/murmer/src/app/bridge.rs
+++ b/murmer/src/app/bridge.rs
@@ -27,10 +27,11 @@ use tokio::sync::mpsc;
 
 use crate::app::coordinator::{
     Coordinator, CoordinatorState, NotifyNodeFailed, NotifyNodeJoined, NotifyNodeLeft,
-    NotifySpawnAck, SerializableNodeInfo,
+    NotifySingletonStopped, NotifySpawnAck, SerializableNodeInfo,
 };
 use crate::app::node_info::NodeInfo;
-use crate::app::spawn_sender::SpawnSender;
+use crate::app::singleton::SingletonGeneration;
+use crate::app::spawn_sender::{SingletonStopRequest, SingletonStopSender, SpawnSender};
 
 /// Start the Coordinator actor and the cluster bridge.
 ///
@@ -62,7 +63,10 @@ pub fn start_coordinator(
 
     let queue_depth = Arc::new(AtomicUsize::new(0));
     let (spawn_tx, spawn_rx) = mpsc::unbounded_channel();
-    let state = state.with_spawn_sender(SpawnSender::new(spawn_tx, Arc::clone(&queue_depth)));
+    let (stop_tx, stop_rx) = mpsc::unbounded_channel();
+    let state = state
+        .with_spawn_sender(SpawnSender::new(spawn_tx, Arc::clone(&queue_depth)))
+        .with_singleton_stop_sender(SingletonStopSender::new(stop_tx));
 
     let coordinator_ep = cluster.start_actor("coordinator", Coordinator, state);
 
@@ -88,6 +92,19 @@ pub fn start_coordinator(
         ack_ep,
         spawn_rx,
         queue_depth,
+    ));
+
+    // Drain loop for graceful singleton stops (the inner half of the drain handoff).
+    let stop_transport = Arc::clone(cluster.transport());
+    let stop_local_node_id = cluster.identity().node_id_string();
+    let stop_receptionist = cluster.receptionist().clone();
+    let stop_ep = coordinator_ep.clone();
+    tokio::spawn(run_singleton_stop_drain_loop(
+        stop_transport,
+        stop_local_node_id,
+        stop_receptionist,
+        stop_ep,
+        stop_rx,
     ));
 
     coordinator_ep
@@ -163,6 +180,20 @@ async fn run_bridge_loop(
                             request_id,
                             success: false,
                             error: Some(error),
+                        })
+                        .await;
+                }
+                ClusterEvent::SingletonStopped {
+                    label,
+                    stopped_generation,
+                } => {
+                    // A drained owner confirmed it stopped — advance the handoff.
+                    let _ = coordinator
+                        .send(NotifySingletonStopped {
+                            label,
+                            stopped_generation: SingletonGeneration::from_packed(
+                                stopped_generation,
+                            ),
                         })
                         .await;
                 }
@@ -310,6 +341,52 @@ async fn run_spawn_drain_loop(
                 }
                 crate::instrument::spawn_drain_factory("remote", factory_start.elapsed());
             });
+        }
+    }
+}
+
+/// Drain loop for graceful singleton stops: reads stop requests and either stops
+/// a local instance directly (then self-notifies the Coordinator) or sends a
+/// `StopSingleton` control message to the remote owner (whose ack returns as
+/// `ClusterEvent::SingletonStopped`).
+async fn run_singleton_stop_drain_loop(
+    transport: Arc<Transport>,
+    local_node_id: String,
+    receptionist: crate::receptionist::Receptionist,
+    coordinator: Endpoint<Coordinator>,
+    mut rx: mpsc::UnboundedReceiver<SingletonStopRequest>,
+) {
+    while let Some(req) = rx.recv().await {
+        if req.target_node_id == local_node_id {
+            tracing::debug!("Stopping local singleton {} for handoff", req.label);
+            receptionist.stop(&req.label);
+            let _ = coordinator
+                .send(NotifySingletonStopped {
+                    label: req.label,
+                    stopped_generation: SingletonGeneration::from_packed(req.generation),
+                })
+                .await;
+        } else {
+            tracing::debug!(
+                "Sending StopSingleton to {} for {}",
+                req.target_node_id,
+                req.label
+            );
+            if let Err(e) = transport
+                .send_control(
+                    &req.target_node_id,
+                    ControlMessage::StopSingleton {
+                        label: req.label.clone(),
+                        generation: req.generation,
+                    },
+                )
+                .await
+            {
+                tracing::warn!(
+                    "Failed to send StopSingleton to {}: {e}",
+                    req.target_node_id
+                );
+            }
         }
     }
 }

--- a/murmer/src/app/coordinator.rs
+++ b/murmer/src/app/coordinator.rs
@@ -28,6 +28,7 @@
 //! ```
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -38,6 +39,10 @@ use crate::app::election::LeaderElection;
 use crate::app::error::OrchestratorError;
 use crate::app::node_info::{ClusterView, NodeInfo};
 use crate::app::placement::{self, PlacementDecision, PlacementStrategy};
+use crate::app::singleton::{
+    CoordinatorGenerationSource, GenerationSource, SingletonOwnership, SingletonPhase,
+    SingletonSpec, resolve_owner,
+};
 use crate::app::spawn_sender::SpawnSender;
 use crate::app::spec::{ActorSpec, CrashStrategy};
 
@@ -65,10 +70,27 @@ pub struct CoordinatorState {
     pub pending_spawns: HashMap<u64, PendingSpawn>,
     /// Specs waiting for a failed node to return, keyed by label.
     pub waiting_for_return: HashMap<String, WaitingSpec>,
+    /// Cluster singletons being managed, keyed by singleton label.
+    pub singletons: HashMap<String, SingletonRuntime>,
+    /// Pluggable authority that mints `(term, seq)` generations for singletons.
+    /// Defaults to an in-RAM source (single-node/tests); inject a durable one
+    /// (e.g. catalog-backed) for multi-node write deployments.
+    pub generation_source: Arc<dyn GenerationSource>,
     /// Monotonic counter for generating unique request IDs.
     next_request_id: u64,
     /// Channel for sending spawn requests to the transport layer.
     spawn_sender: Option<SpawnSender>,
+}
+
+/// Which managed aggregate a pending spawn belongs to, so its ack can be routed
+/// to the right bookkeeping. `None` = an ordinary standalone spec.
+///
+/// (A `Group(label)` variant is added when PlacementGroup / M2 lands; unifying
+/// the back-reference here keeps `notify_spawn_ack` a single code path.)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OwnerKey {
+    /// The spawn is the active instance of this cluster singleton.
+    Singleton(String),
 }
 
 /// A spawn request that's been sent but not yet acknowledged.
@@ -76,6 +98,19 @@ pub struct CoordinatorState {
 pub struct PendingSpawn {
     pub spec_label: String,
     pub target_node_id: String,
+    /// The managed aggregate this spawn belongs to (singleton/group), if any.
+    pub owner: Option<OwnerKey>,
+}
+
+/// Coordinator-side runtime record for a managed cluster singleton.
+///
+/// `ownership` is a soft cache of the authoritative record (the durable copy
+/// lives in the [`GenerationSource`]'s backing store); it is `None` between spec
+/// registration and the first grant.
+#[derive(Debug, Clone)]
+pub struct SingletonRuntime {
+    pub spec: SingletonSpec,
+    pub ownership: Option<SingletonOwnership>,
 }
 
 /// A spec whose node failed but is using WaitForReturn strategy.
@@ -116,6 +151,23 @@ pub struct GetClusterView;
 #[derive(Debug, Clone, Serialize, Deserialize, Message)]
 #[message(result = Vec<SpecStatus>, remote = "coordinator::GetSpecs")]
 pub struct GetSpecs;
+
+/// Declare (or idempotently re-assert) a cluster singleton. The Coordinator
+/// resolves the anchor to one owner node, mints a fresh `(term, seq)`
+/// generation, and spawns the single instance there. Returns the granted
+/// ownership.
+#[derive(Debug, Clone, Serialize, Deserialize, Message)]
+#[message(result = Result<SingletonOwnership, String>, remote = "coordinator::StartSingleton")]
+pub struct StartSingleton {
+    pub spec: SingletonSpec,
+}
+
+/// Query the current ownership of a cluster singleton (`None` if unknown).
+#[derive(Debug, Clone, Serialize, Deserialize, Message)]
+#[message(result = Option<SingletonOwnership>, remote = "coordinator::GetSingleton")]
+pub struct GetSingleton {
+    pub label: String,
+}
 
 /// Notify the coordinator that a node has joined.
 #[derive(Debug, Clone, Serialize, Deserialize, Message)]
@@ -261,6 +313,7 @@ impl Coordinator {
             PendingSpawn {
                 spec_label: label,
                 target_node_id: decision.node_id.clone(),
+                owner: None,
             },
         );
 
@@ -407,6 +460,7 @@ impl Coordinator {
                     PendingSpawn {
                         spec_label: ws.spec.label.clone(),
                         target_node_id: msg.node_id.clone(),
+                        owner: None,
                     },
                 );
                 state.send_spawn(&msg.node_id, request_id, &ws.spec);
@@ -465,12 +519,21 @@ impl Coordinator {
                 state
                     .cluster_view
                     .add_actor(&pending.target_node_id, &pending.spec_label);
+                // A singleton's instance is now running — promote it to Active.
+                if let Some(OwnerKey::Singleton(label)) = &pending.owner
+                    && let Some(rt) = state.singletons.get_mut(label)
+                    && let Some(ownership) = &mut rt.ownership
+                {
+                    ownership.phase = SingletonPhase::Active;
+                }
             } else {
                 tracing::warn!(
                     "Spawn failed for {}: {}",
                     pending.spec_label,
                     msg.error.as_deref().unwrap_or("unknown error")
                 );
+                // A failed singleton spawn stays in `Starting`; re-placement /
+                // fenced handoff retry is handled by the M4 step-4 machinery.
             }
         }
     }
@@ -501,6 +564,7 @@ impl Coordinator {
                     PendingSpawn {
                         spec_label: msg.label.clone(),
                         target_node_id: decision.node_id.clone(),
+                        owner: None,
                     },
                 );
                 state.send_spawn(&decision.node_id, request_id, &ws.spec);
@@ -518,6 +582,106 @@ impl Coordinator {
             }
         }
         // If not in waiting_for_return, the node already returned — timer is a no-op
+    }
+
+    #[handler]
+    async fn start_singleton(
+        &mut self,
+        _ctx: &ActorContext<Self>,
+        state: &mut CoordinatorState,
+        msg: StartSingleton,
+    ) -> Result<SingletonOwnership, String> {
+        if !state.is_leader() {
+            return Err(OrchestratorError::NotLeader.to_string());
+        }
+
+        let label = msg.spec.label.clone();
+
+        // Resolve the anchor to exactly one owner node.
+        let owner = resolve_owner(
+            &msg.spec.anchor,
+            &state.cluster_view,
+            state.election.as_ref(),
+        )
+        .ok_or_else(|| {
+            OrchestratorError::NoEligibleNodes {
+                reason: format!("no node satisfies anchor for singleton {label}"),
+            }
+            .to_string()
+        })?;
+
+        // Idempotent re-assert: the same owner is already Active — bump `seq`
+        // within the term (liveness renew), do NOT spawn a second instance.
+        let reassert = state
+            .singletons
+            .get(&label)
+            .and_then(|rt| rt.ownership.as_ref())
+            .is_some_and(|own| {
+                own.owner_node_id.as_deref() == Some(owner.as_str())
+                    && own.phase == SingletonPhase::Active
+            });
+        if reassert {
+            let gen_source = state.generation_source.clone();
+            let generation = gen_source.claim_seq(&label).await?;
+            let ownership = SingletonOwnership {
+                label: label.clone(),
+                owner_node_id: Some(owner),
+                generation,
+                phase: SingletonPhase::Active,
+            };
+            if let Some(rt) = state.singletons.get_mut(&label) {
+                rt.ownership = Some(ownership.clone());
+            }
+            tracing::info!("Re-asserted singleton {label} (gen={generation:?})");
+            return Ok(ownership);
+        }
+
+        // Fresh grant: bump `term`, reset `seq` — a new ownership epoch.
+        let gen_source = state.generation_source.clone();
+        let generation = gen_source.claim_term(&label, &owner).await?;
+        let ownership = SingletonOwnership {
+            label: label.clone(),
+            owner_node_id: Some(owner.clone()),
+            generation,
+            // Active is set when the spawn ack lands (notify_spawn_ack).
+            phase: SingletonPhase::Starting,
+        };
+        state.singletons.insert(
+            label.clone(),
+            SingletonRuntime {
+                spec: msg.spec.clone(),
+                ownership: Some(ownership.clone()),
+            },
+        );
+
+        // Spawn the single instance on the owner, stamping the packed generation
+        // so the actor's fence rides the same value a downstream compare uses.
+        let request_id = state.next_request_id();
+        state.pending_spawns.insert(
+            request_id,
+            PendingSpawn {
+                spec_label: label.clone(),
+                target_node_id: owner.clone(),
+                owner: Some(OwnerKey::Singleton(label.clone())),
+            },
+        );
+        state.send_singleton_spawn(&owner, request_id, &msg.spec, generation.packed());
+
+        tracing::info!("Starting singleton {label} on {owner} (gen={generation:?})");
+        Ok(ownership)
+    }
+
+    #[handler]
+    fn get_singleton(
+        &mut self,
+        _ctx: &ActorContext<Self>,
+        state: &mut CoordinatorState,
+        msg: GetSingleton,
+    ) -> Option<SingletonOwnership> {
+        state
+            .singletons
+            .get(&msg.label)
+            .and_then(|rt| rt.ownership.clone())
     }
 }
 
@@ -540,6 +704,8 @@ impl CoordinatorState {
             local_node_id: local_node_id.into(),
             pending_spawns: HashMap::new(),
             waiting_for_return: HashMap::new(),
+            singletons: HashMap::new(),
+            generation_source: Arc::new(CoordinatorGenerationSource::new()),
             next_request_id: 0,
             spawn_sender: None,
         }
@@ -548,6 +714,14 @@ impl CoordinatorState {
     /// Set the spawn sender for sending spawn requests to the transport layer.
     pub(crate) fn with_spawn_sender(mut self, sender: SpawnSender) -> Self {
         self.spawn_sender = Some(sender);
+        self
+    }
+
+    /// Inject a durable [`GenerationSource`] for minting singleton generations.
+    /// Multi-node write deployments MUST set this (the default in-RAM source is
+    /// not durable across a Coordinator restart).
+    pub fn with_generation_source(mut self, source: Arc<dyn GenerationSource>) -> Self {
+        self.generation_source = source;
         self
     }
 
@@ -581,6 +755,34 @@ impl CoordinatorState {
         } else {
             tracing::warn!(
                 "No spawn sender configured — spawn request for {} dropped",
+                spec.label
+            );
+        }
+    }
+
+    /// Send a spawn request for a fenced cluster singleton, stamping the packed
+    /// `(term, seq)` generation onto the request.
+    fn send_singleton_spawn(
+        &self,
+        target_node_id: &str,
+        request_id: u64,
+        spec: &SingletonSpec,
+        generation: u64,
+    ) {
+        if let Some(sender) = &self.spawn_sender {
+            sender.send_spawn(
+                target_node_id,
+                SpawnRequest {
+                    request_id,
+                    label: spec.label.clone(),
+                    actor_type_name: spec.actor_type_name.clone(),
+                    initial_state: spec.initial_state.clone(),
+                    singleton_generation: Some(generation),
+                },
+            );
+        } else {
+            tracing::warn!(
+                "No spawn sender configured — singleton spawn for {} dropped",
                 spec.label
             );
         }
@@ -670,6 +872,7 @@ impl CoordinatorState {
                             PendingSpawn {
                                 spec_label: label.clone(),
                                 target_node_id: decision.node_id.clone(),
+                                owner: None,
                             },
                         );
                         self.send_spawn(&decision.node_id, request_id, &spec);
@@ -694,6 +897,7 @@ mod tests {
     use super::*;
     use crate::app::election::OldestNode;
     use crate::app::placement::LeastLoaded;
+    use crate::app::singleton::{SingletonAnchor, SingletonGeneration, SingletonSpec};
     use crate::cluster::config::{NodeClass, NodeIdentity};
 
     fn make_system_and_coordinator() -> (crate::System, Endpoint<Coordinator>) {
@@ -967,5 +1171,140 @@ mod tests {
         let specs = coordinator.send(GetSpecs).await.unwrap();
         assert_eq!(specs.len(), 1);
         assert!(matches!(specs[0].state, SpecState::Pending));
+    }
+
+    // ── Cluster singletons (M4 step 3) ──────────────────────────────────────
+    // The harness configures no spawn_sender, so the spawn warn-drops and the
+    // ack must be injected manually; the first allocated request_id is 0.
+
+    #[tokio::test]
+    async fn test_start_singleton_grants_ownership_on_leader() {
+        let (_system, coordinator) = make_system_and_coordinator();
+
+        let ownership = coordinator
+            .send_async(StartSingleton {
+                spec: SingletonSpec::new("catalog", "app::Catalog", SingletonAnchor::Leader),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Leader (oldest = alpha, incarnation 1) owns it; first grant is term 1.
+        assert!(
+            ownership
+                .owner_node_id
+                .as_deref()
+                .unwrap()
+                .contains("alpha"),
+            "leader anchor should resolve to alpha, got {:?}",
+            ownership.owner_node_id
+        );
+        assert_eq!(
+            ownership.generation,
+            SingletonGeneration { term: 1, seq: 0 }
+        );
+        // Active only lands once the spawn ack is observed.
+        assert_eq!(ownership.phase, SingletonPhase::Starting);
+
+        let queried = coordinator
+            .send(GetSingleton {
+                label: "catalog".into(),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(queried.generation, ownership.generation);
+    }
+
+    #[tokio::test]
+    async fn test_singleton_ack_promotes_to_active() {
+        let (_system, coordinator) = make_system_and_coordinator();
+
+        coordinator
+            .send_async(StartSingleton {
+                spec: SingletonSpec::new("catalog", "app::Catalog", SingletonAnchor::Leader),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Simulate the owner's spawn ack (request_id 0 is the first allocated).
+        coordinator
+            .send(NotifySpawnAck {
+                request_id: 0,
+                success: true,
+                error: None,
+            })
+            .await
+            .unwrap();
+
+        let queried = coordinator
+            .send(GetSingleton {
+                label: "catalog".into(),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(queried.phase, SingletonPhase::Active);
+        assert_eq!(queried.generation, SingletonGeneration { term: 1, seq: 0 });
+    }
+
+    #[tokio::test]
+    async fn test_start_singleton_idempotent_reasserts_with_seq_bump() {
+        let (_system, coordinator) = make_system_and_coordinator();
+
+        let spec = SingletonSpec::new("catalog", "app::Catalog", SingletonAnchor::Leader);
+        coordinator
+            .send_async(StartSingleton { spec: spec.clone() })
+            .await
+            .unwrap()
+            .unwrap();
+        coordinator
+            .send(NotifySpawnAck {
+                request_id: 0,
+                success: true,
+                error: None,
+            })
+            .await
+            .unwrap();
+
+        // Re-assert against the same Active owner: bump seq within the term,
+        // no new ownership epoch, no second spawn.
+        let reasserted = coordinator
+            .send_async(StartSingleton { spec })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            reasserted.generation,
+            SingletonGeneration { term: 1, seq: 1 }
+        );
+        assert_eq!(reasserted.phase, SingletonPhase::Active);
+    }
+
+    #[tokio::test]
+    async fn test_start_singleton_unsatisfiable_anchor_errors() {
+        let (_system, coordinator) = make_system_and_coordinator();
+
+        let result = coordinator
+            .send_async(StartSingleton {
+                spec: SingletonSpec::new(
+                    "catalog",
+                    "app::Catalog",
+                    SingletonAnchor::Node("ghost@127.0.0.1:9999#0".into()),
+                ),
+            })
+            .await
+            .unwrap();
+        assert!(result.is_err(), "pinning to a missing node should fail");
+
+        // And nothing was registered.
+        let queried = coordinator
+            .send(GetSingleton {
+                label: "catalog".into(),
+            })
+            .await
+            .unwrap();
+        assert!(queried.is_none());
     }
 }

--- a/murmer/src/app/coordinator.rs
+++ b/murmer/src/app/coordinator.rs
@@ -575,6 +575,7 @@ impl CoordinatorState {
                     label: spec.label.clone(),
                     actor_type_name: spec.actor_type_name.clone(),
                     initial_state: spec.initial_state.clone(),
+                    singleton_generation: None,
                 },
             );
         } else {

--- a/murmer/src/app/coordinator.rs
+++ b/murmer/src/app/coordinator.rs
@@ -469,7 +469,7 @@ impl Coordinator {
     }
 
     #[handler]
-    fn notify_node_failed(
+    async fn notify_node_failed(
         &mut self,
         ctx: &ActorContext<Self>,
         state: &mut CoordinatorState,
@@ -487,10 +487,16 @@ impl Coordinator {
                 let _ = endpoint.send(WaitForReturnTimeout { label }).await;
             });
         }
+
+        // Re-place any singleton the failed node owned. The failed owner is gone
+        // (SWIM-confirmed), so we do NOT drain it — we mint a strictly-higher
+        // term and re-spawn; a zombie ex-owner is fenced by the `(term, seq)`
+        // compare on its next write. (Graceful drain handoff is M3.)
+        state.redrive_singletons_after_loss(&msg.node_id).await;
     }
 
     #[handler]
-    fn notify_node_left(
+    async fn notify_node_left(
         &mut self,
         _ctx: &ActorContext<Self>,
         state: &mut CoordinatorState,
@@ -500,6 +506,9 @@ impl Coordinator {
         // Graceful departures never produce WaitForReturn timers (guarded by !graceful)
         let _timers = state.handle_node_departure(&msg.node_id, true);
         state.cluster_view.remove_node(&msg.node_id);
+
+        // Re-place any singleton the departed node owned (fenced by a new term).
+        state.redrive_singletons_after_loss(&msg.node_id).await;
     }
 
     #[handler]
@@ -788,6 +797,79 @@ impl CoordinatorState {
         }
     }
 
+    /// Re-place every singleton that was owned by a node that just left/failed.
+    ///
+    /// The lost owner is already excluded from the view (`mark_failed` /
+    /// `remove_node`), so `resolve_owner` lands on a survivor. Each re-drive
+    /// mints a fresh `term` (strictly greater than the lost owner's), so even a
+    /// zombie ex-owner that resurfaces is fenced by the `(term, seq)` compare.
+    async fn redrive_singletons_after_loss(&mut self, lost_node_id: &str) {
+        let affected: Vec<String> = self
+            .singletons
+            .iter()
+            .filter(|(_, rt)| {
+                rt.ownership
+                    .as_ref()
+                    .and_then(|o| o.owner_node_id.as_deref())
+                    == Some(lost_node_id)
+            })
+            .map(|(label, _)| label.clone())
+            .collect();
+
+        for label in affected {
+            let Some(spec) = self.singletons.get(&label).map(|rt| rt.spec.clone()) else {
+                continue;
+            };
+
+            let Some(new_owner) =
+                resolve_owner(&spec.anchor, &self.cluster_view, self.election.as_ref())
+            else {
+                tracing::warn!(
+                    "Singleton {label} lost owner {lost_node_id} — no eligible node remains"
+                );
+                if let Some(rt) = self.singletons.get_mut(&label)
+                    && let Some(ownership) = &mut rt.ownership
+                {
+                    ownership.owner_node_id = None;
+                }
+                continue;
+            };
+
+            let gen_source = self.generation_source.clone();
+            let generation = match gen_source.claim_term(&label, &new_owner).await {
+                Ok(generation) => generation,
+                Err(e) => {
+                    tracing::error!("claim_term failed re-driving singleton {label}: {e}");
+                    continue;
+                }
+            };
+
+            if let Some(rt) = self.singletons.get_mut(&label) {
+                rt.ownership = Some(SingletonOwnership {
+                    label: label.clone(),
+                    owner_node_id: Some(new_owner.clone()),
+                    generation,
+                    phase: SingletonPhase::Starting,
+                });
+            }
+
+            let request_id = self.next_request_id();
+            self.pending_spawns.insert(
+                request_id,
+                PendingSpawn {
+                    spec_label: label.clone(),
+                    target_node_id: new_owner.clone(),
+                    owner: Some(OwnerKey::Singleton(label.clone())),
+                },
+            );
+            self.send_singleton_spawn(&new_owner, request_id, &spec, generation.packed());
+
+            tracing::info!(
+                "Re-drove singleton {label} to {new_owner} after loss of {lost_node_id} (gen={generation:?})"
+            );
+        }
+    }
+
     /// Handle a node departure — shared logic for both failure and graceful leave.
     ///
     /// When `graceful` is true (node left voluntarily), WaitForReturn is
@@ -1033,7 +1115,7 @@ mod tests {
         let original_node = result.node_id.clone();
 
         coordinator
-            .send(NotifyNodeFailed {
+            .send_async(NotifyNodeFailed {
                 node_id: original_node.clone(),
             })
             .await
@@ -1072,7 +1154,7 @@ mod tests {
             .unwrap();
 
         coordinator
-            .send(NotifyNodeFailed {
+            .send_async(NotifyNodeFailed {
                 node_id: result.node_id,
             })
             .await
@@ -1109,7 +1191,7 @@ mod tests {
         let original_node = result.node_id.clone();
 
         coordinator
-            .send(NotifyNodeFailed {
+            .send_async(NotifyNodeFailed {
                 node_id: original_node.clone(),
             })
             .await
@@ -1147,7 +1229,7 @@ mod tests {
         let original_node = result.node_id.clone();
 
         coordinator
-            .send(NotifyNodeFailed {
+            .send_async(NotifyNodeFailed {
                 node_id: original_node.clone(),
             })
             .await
@@ -1306,5 +1388,135 @@ mod tests {
             .await
             .unwrap();
         assert!(queried.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_singleton_redrives_on_owner_failure_with_higher_term() {
+        let (_system, coordinator) = make_system_and_coordinator();
+
+        coordinator
+            .send_async(StartSingleton {
+                spec: SingletonSpec::new("catalog", "app::Catalog", SingletonAnchor::Leader),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        coordinator
+            .send(NotifySpawnAck {
+                request_id: 0,
+                success: true,
+                error: None,
+            })
+            .await
+            .unwrap();
+
+        let before = coordinator
+            .send(GetSingleton {
+                label: "catalog".into(),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        let original_owner = before.owner_node_id.clone().unwrap();
+        assert!(original_owner.contains("alpha"));
+        assert_eq!(before.generation, SingletonGeneration { term: 1, seq: 0 });
+
+        // The owner fails: re-drive to the survivor with a strictly-higher term
+        // (the fence), Starting until the re-spawn acks.
+        coordinator
+            .send_async(NotifyNodeFailed {
+                node_id: original_owner.clone(),
+            })
+            .await
+            .unwrap();
+
+        let after = coordinator
+            .send(GetSingleton {
+                label: "catalog".into(),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            after.owner_node_id.as_deref().unwrap().contains("beta"),
+            "must move off the failed node to beta, got {:?}",
+            after.owner_node_id
+        );
+        assert_eq!(after.generation, SingletonGeneration { term: 2, seq: 0 });
+        assert!(
+            after.generation > before.generation,
+            "term must strictly increase across failover (the fence)"
+        );
+        assert_eq!(after.phase, SingletonPhase::Starting);
+
+        // The re-drive's spawn (request_id 1) acks -> Active.
+        coordinator
+            .send(NotifySpawnAck {
+                request_id: 1,
+                success: true,
+                error: None,
+            })
+            .await
+            .unwrap();
+        let active = coordinator
+            .send(GetSingleton {
+                label: "catalog".into(),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(active.phase, SingletonPhase::Active);
+    }
+
+    #[tokio::test]
+    async fn test_singleton_node_anchor_owner_loss_clears_owner() {
+        let (_system, coordinator) = make_system_and_coordinator();
+        let alpha_id = NodeIdentity {
+            name: "alpha".into(),
+            host: "127.0.0.1".into(),
+            port: 7100,
+            incarnation: 1,
+        }
+        .node_id_string();
+
+        coordinator
+            .send_async(StartSingleton {
+                spec: SingletonSpec::new(
+                    "catalog",
+                    "app::Catalog",
+                    SingletonAnchor::Node(alpha_id.clone()),
+                ),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        coordinator
+            .send(NotifySpawnAck {
+                request_id: 0,
+                success: true,
+                error: None,
+            })
+            .await
+            .unwrap();
+
+        // The pinned node fails and the Node anchor cannot resolve elsewhere —
+        // ownership is cleared (no silent relocation off the pin).
+        coordinator
+            .send_async(NotifyNodeFailed { node_id: alpha_id })
+            .await
+            .unwrap();
+
+        let after = coordinator
+            .send(GetSingleton {
+                label: "catalog".into(),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            after.owner_node_id.is_none(),
+            "a Node-pinned singleton whose anchor died has no owner, got {:?}",
+            after.owner_node_id
+        );
     }
 }

--- a/murmer/src/app/coordinator.rs
+++ b/murmer/src/app/coordinator.rs
@@ -29,6 +29,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -40,10 +41,10 @@ use crate::app::error::OrchestratorError;
 use crate::app::node_info::{ClusterView, NodeInfo};
 use crate::app::placement::{self, PlacementDecision, PlacementStrategy};
 use crate::app::singleton::{
-    CoordinatorGenerationSource, GenerationSource, SingletonOwnership, SingletonPhase,
-    SingletonSpec, resolve_owner,
+    CoordinatorGenerationSource, GenerationSource, SingletonGeneration, SingletonOwnership,
+    SingletonPhase, SingletonSpec, resolve_owner,
 };
-use crate::app::spawn_sender::SpawnSender;
+use crate::app::spawn_sender::{SingletonStopRequest, SingletonStopSender, SpawnSender};
 use crate::app::spec::{ActorSpec, CrashStrategy};
 
 // =============================================================================
@@ -80,6 +81,8 @@ pub struct CoordinatorState {
     next_request_id: u64,
     /// Channel for sending spawn requests to the transport layer.
     spawn_sender: Option<SpawnSender>,
+    /// Channel for sending graceful singleton-stop requests to the transport.
+    singleton_stop_sender: Option<SingletonStopSender>,
 }
 
 /// Which managed aggregate a pending spawn belongs to, so its ack can be routed
@@ -111,6 +114,36 @@ pub struct PendingSpawn {
 pub struct SingletonRuntime {
     pub spec: SingletonSpec,
     pub ownership: Option<SingletonOwnership>,
+    /// Set while a graceful drain handoff is in flight (Draining): the old owner
+    /// has been asked to stop and we are awaiting its stopped-ack (or the drain
+    /// timeout) before placing the next owner.
+    pub pending_handoff: Option<PendingHandoff>,
+}
+
+/// In-flight graceful handoff bookkeeping for a singleton.
+///
+/// Graceful handoff is the drain-then-place path (live rebalance / explicit
+/// teardown), distinct from failover (a dead owner re-drives immediately). The
+/// new term is minted up front, so even if the old owner is abandoned on a drain
+/// timeout it is strictly-lower-fenced.
+#[derive(Debug, Clone)]
+pub struct PendingHandoff {
+    /// The owner being drained (the instance asked to stop).
+    pub old_owner: String,
+    /// The generation that owner was running — echoed in stop/ack to fence a
+    /// superseded owner, and used to ignore stale stopped-acks.
+    pub old_generation: SingletonGeneration,
+    /// Where the singleton is moving TO, with its freshly-minted (higher)
+    /// generation. `None` = teardown (no successor; the runtime is removed once
+    /// the old owner stops).
+    pub destination: Option<HandoffDestination>,
+}
+
+/// The successor of a graceful move handoff.
+#[derive(Debug, Clone)]
+pub struct HandoffDestination {
+    pub new_owner: String,
+    pub new_generation: SingletonGeneration,
 }
 
 /// A spec whose node failed but is using WaitForReturn strategy.
@@ -167,6 +200,44 @@ pub struct StartSingleton {
 #[message(result = Option<SingletonOwnership>, remote = "coordinator::GetSingleton")]
 pub struct GetSingleton {
     pub label: String,
+}
+
+/// Gracefully MOVE a singleton to wherever its anchor currently resolves: mint a
+/// higher term, drain the (live) old owner, then place the new one. A no-op if
+/// the resolved owner is unchanged. Use for rebalance / anchor changes; a dead
+/// owner is handled by failover instead.
+#[derive(Debug, Clone, Serialize, Deserialize, Message)]
+#[message(result = Result<(), String>, remote = "coordinator::MoveSingleton")]
+pub struct MoveSingleton {
+    pub label: String,
+}
+
+/// Gracefully tear down a singleton: drain the (live) owner, then forget it.
+#[derive(Debug, Clone, Serialize, Deserialize, Message)]
+#[message(result = Result<(), String>, remote = "coordinator::StopSingleton")]
+pub struct StopSingleton {
+    pub label: String,
+}
+
+/// The draining owner confirmed it has stopped (forwarded by the bridge from the
+/// `SingletonStoppedAck` control message). Advances the handoff: place the new
+/// owner, or finish a teardown. A stale-generation ack is ignored.
+#[derive(Debug, Clone, Serialize, Deserialize, Message)]
+#[message(result = (), remote = "coordinator::NotifySingletonStopped")]
+pub struct NotifySingletonStopped {
+    pub label: String,
+    pub stopped_generation: SingletonGeneration,
+}
+
+/// Internal: a graceful drain didn't ack within `drain_timeout` — force-proceed
+/// (the abandoned old owner is strictly-lower-fenced).
+#[derive(Debug, Clone, Serialize, Deserialize, Message)]
+#[message(result = (), remote = "coordinator::SingletonDrainTimeout")]
+pub struct SingletonDrainTimeout {
+    pub label: String,
+    /// The generation being drained — identifies the specific in-flight handoff
+    /// so a timer for a superseded handoff is ignored.
+    pub drained_generation: SingletonGeneration,
 }
 
 /// Notify the coordinator that a node has joined.
@@ -660,6 +731,7 @@ impl Coordinator {
             SingletonRuntime {
                 spec: msg.spec.clone(),
                 ownership: Some(ownership.clone()),
+                pending_handoff: None,
             },
         );
 
@@ -692,6 +764,170 @@ impl Coordinator {
             .get(&msg.label)
             .and_then(|rt| rt.ownership.clone())
     }
+
+    #[handler]
+    async fn move_singleton(
+        &mut self,
+        ctx: &ActorContext<Self>,
+        state: &mut CoordinatorState,
+        msg: MoveSingleton,
+    ) -> Result<(), String> {
+        if !state.is_leader() {
+            return Err(OrchestratorError::NotLeader.to_string());
+        }
+        let label = msg.label;
+
+        // Snapshot what we need before any await.
+        let Some(rt) = state.singletons.get(&label) else {
+            return Err(format!("singleton {label} not found"));
+        };
+        if rt.pending_handoff.is_some() {
+            return Err(format!("singleton {label} handoff already in progress"));
+        }
+        let Some(ownership) = rt.ownership.clone() else {
+            return Err(format!("singleton {label} has no current owner to move"));
+        };
+        let Some(current) = ownership.owner_node_id.clone() else {
+            return Err(format!("singleton {label} has no current owner to move"));
+        };
+        let current_gen = ownership.generation;
+        let anchor = rt.spec.anchor.clone();
+        let drain_timeout = rt.spec.drain_timeout;
+
+        let Some(new_owner) = resolve_owner(&anchor, &state.cluster_view, state.election.as_ref())
+        else {
+            return Err(OrchestratorError::NoEligibleNodes {
+                reason: format!("no node satisfies anchor for singleton {label}"),
+            }
+            .to_string());
+        };
+        if new_owner == current {
+            return Ok(()); // anchor unchanged — nothing to move
+        }
+        // A graceful move drains a LIVE owner; a dead owner is failover's job.
+        let old_alive = state
+            .cluster_view
+            .nodes
+            .get(&current)
+            .map(|n| n.is_alive)
+            .unwrap_or(false);
+        if !old_alive {
+            return Err(format!(
+                "singleton {label} owner {current} is not alive — handled by failover, not graceful move"
+            ));
+        }
+
+        // Mint the successor generation up front (strictly higher than current).
+        let gen_source = state.generation_source.clone();
+        let new_gen = gen_source.claim_term(&label, &new_owner).await?;
+
+        // Enter Draining — ownership still points at the old, running owner.
+        if let Some(rt) = state.singletons.get_mut(&label) {
+            if let Some(own) = &mut rt.ownership {
+                own.phase = SingletonPhase::Draining;
+            }
+            rt.pending_handoff = Some(PendingHandoff {
+                old_owner: current.clone(),
+                old_generation: current_gen,
+                destination: Some(HandoffDestination {
+                    new_owner: new_owner.clone(),
+                    new_generation: new_gen,
+                }),
+            });
+        }
+        state.send_stop_singleton(&current, &label, current_gen.packed());
+        state.schedule_drain_timeout(ctx, &label, current_gen, drain_timeout);
+
+        tracing::info!(
+            "Graceful move of singleton {label}: draining {current} (gen={current_gen:?}) -> {new_owner} (gen={new_gen:?})"
+        );
+        Ok(())
+    }
+
+    #[handler]
+    fn stop_singleton(
+        &mut self,
+        ctx: &ActorContext<Self>,
+        state: &mut CoordinatorState,
+        msg: StopSingleton,
+    ) -> Result<(), String> {
+        if !state.is_leader() {
+            return Err(OrchestratorError::NotLeader.to_string());
+        }
+        let label = msg.label;
+
+        let Some(rt) = state.singletons.get(&label) else {
+            return Err(format!("singleton {label} not found"));
+        };
+        if rt.pending_handoff.is_some() {
+            return Err(format!("singleton {label} handoff already in progress"));
+        }
+        let current = rt.ownership.as_ref().and_then(|o| o.owner_node_id.clone());
+        let current_gen = rt.ownership.as_ref().map(|o| o.generation);
+        let drain_timeout = rt.spec.drain_timeout;
+
+        // No live owner to drain — just forget it.
+        let old_alive = current
+            .as_ref()
+            .and_then(|c| state.cluster_view.nodes.get(c))
+            .map(|n| n.is_alive)
+            .unwrap_or(false);
+        if !old_alive {
+            state.singletons.remove(&label);
+            tracing::info!("Singleton {label} torn down (no live owner to drain)");
+            return Ok(());
+        }
+        let (current, current_gen) = (current.unwrap(), current_gen.unwrap());
+
+        if let Some(rt) = state.singletons.get_mut(&label) {
+            if let Some(own) = &mut rt.ownership {
+                own.phase = SingletonPhase::Draining;
+            }
+            rt.pending_handoff = Some(PendingHandoff {
+                old_owner: current.clone(),
+                old_generation: current_gen,
+                destination: None, // teardown
+            });
+        }
+        state.send_stop_singleton(&current, &label, current_gen.packed());
+        state.schedule_drain_timeout(ctx, &label, current_gen, drain_timeout);
+        tracing::info!("Tearing down singleton {label}: draining {current} (gen={current_gen:?})");
+        Ok(())
+    }
+
+    #[handler]
+    fn notify_singleton_stopped(
+        &mut self,
+        _ctx: &ActorContext<Self>,
+        state: &mut CoordinatorState,
+        msg: NotifySingletonStopped,
+    ) {
+        state.complete_handoff(&msg.label, msg.stopped_generation);
+    }
+
+    #[handler]
+    fn singleton_drain_timeout(
+        &mut self,
+        _ctx: &ActorContext<Self>,
+        state: &mut CoordinatorState,
+        msg: SingletonDrainTimeout,
+    ) {
+        // Only fire if this timer matches the still-in-flight handoff (a timer
+        // for a superseded handoff is ignored).
+        let still_draining = state
+            .singletons
+            .get(&msg.label)
+            .and_then(|rt| rt.pending_handoff.as_ref())
+            .map(|h| h.old_generation == msg.drained_generation)
+            .unwrap_or(false);
+        if still_draining {
+            tracing::warn!(
+                "Singleton {} drain timed out — force-proceeding; old owner abandoned (strictly-lower-fenced)",
+                msg.label
+            );
+            state.complete_handoff(&msg.label, msg.drained_generation);
+        }
+    }
 }
 
 // =============================================================================
@@ -717,12 +953,19 @@ impl CoordinatorState {
             generation_source: Arc::new(CoordinatorGenerationSource::new()),
             next_request_id: 0,
             spawn_sender: None,
+            singleton_stop_sender: None,
         }
     }
 
     /// Set the spawn sender for sending spawn requests to the transport layer.
     pub(crate) fn with_spawn_sender(mut self, sender: SpawnSender) -> Self {
         self.spawn_sender = Some(sender);
+        self
+    }
+
+    /// Set the channel used to request graceful singleton stops.
+    pub(crate) fn with_singleton_stop_sender(mut self, sender: SingletonStopSender) -> Self {
+        self.singleton_stop_sender = Some(sender);
         self
     }
 
@@ -867,6 +1110,105 @@ impl CoordinatorState {
             tracing::info!(
                 "Re-drove singleton {label} to {new_owner} after loss of {lost_node_id} (gen={generation:?})"
             );
+        }
+    }
+
+    /// Queue a graceful stop of the singleton instance running on `target`.
+    fn send_stop_singleton(&self, target_node_id: &str, label: &str, generation: u64) {
+        if let Some(sender) = &self.singleton_stop_sender {
+            sender.send_stop(SingletonStopRequest {
+                target_node_id: target_node_id.to_string(),
+                label: label.to_string(),
+                generation,
+            });
+        } else {
+            tracing::warn!("No singleton stop sender configured — stop for {label} dropped");
+        }
+    }
+
+    /// Arm a drain-timeout timer for an in-flight handoff, if the spec set one.
+    /// `None` (the default) means wait indefinitely for the stopped-ack.
+    fn schedule_drain_timeout(
+        &self,
+        ctx: &ActorContext<Coordinator>,
+        label: &str,
+        drained_generation: SingletonGeneration,
+        drain_timeout: Option<Duration>,
+    ) {
+        if let Some(duration) = drain_timeout {
+            let endpoint = ctx.endpoint();
+            let label = label.to_string();
+            tokio::spawn(async move {
+                tokio::time::sleep(duration).await;
+                let _ = endpoint
+                    .send(SingletonDrainTimeout {
+                        label,
+                        drained_generation,
+                    })
+                    .await;
+            });
+        }
+    }
+
+    /// Advance an in-flight graceful handoff once the old owner has stopped (or
+    /// the drain timed out). Ignores a stale ack whose generation doesn't match
+    /// the one being drained. Places the successor (move) or forgets the
+    /// singleton (teardown).
+    fn complete_handoff(&mut self, label: &str, stopped_generation: SingletonGeneration) {
+        let Some(handoff) = self
+            .singletons
+            .get(label)
+            .and_then(|rt| rt.pending_handoff.clone())
+        else {
+            return; // not draining — nothing to advance
+        };
+        if handoff.old_generation != stopped_generation {
+            tracing::debug!(
+                "Ignoring stale stopped-ack for singleton {label}: {stopped_generation:?} != draining {:?}",
+                handoff.old_generation
+            );
+            return;
+        }
+
+        match handoff.destination {
+            None => {
+                self.singletons.remove(label);
+                tracing::info!("Singleton {label} torn down (owner drained)");
+            }
+            Some(dest) => {
+                let spec = self.singletons.get(label).map(|rt| rt.spec.clone());
+                if let Some(rt) = self.singletons.get_mut(label) {
+                    rt.pending_handoff = None;
+                    rt.ownership = Some(SingletonOwnership {
+                        label: label.to_string(),
+                        owner_node_id: Some(dest.new_owner.clone()),
+                        generation: dest.new_generation,
+                        phase: SingletonPhase::Starting,
+                    });
+                }
+                let request_id = self.next_request_id();
+                self.pending_spawns.insert(
+                    request_id,
+                    PendingSpawn {
+                        spec_label: label.to_string(),
+                        target_node_id: dest.new_owner.clone(),
+                        owner: Some(OwnerKey::Singleton(label.to_string())),
+                    },
+                );
+                if let Some(spec) = spec {
+                    self.send_singleton_spawn(
+                        &dest.new_owner,
+                        request_id,
+                        &spec,
+                        dest.new_generation.packed(),
+                    );
+                }
+                tracing::info!(
+                    "Singleton {label} drained — placing new owner {} (gen={:?})",
+                    dest.new_owner,
+                    dest.new_generation
+                );
+            }
         }
     }
 
@@ -1518,5 +1860,291 @@ mod tests {
             "a Node-pinned singleton whose anchor died has no owner, got {:?}",
             after.owner_node_id
         );
+    }
+
+    // ── Graceful drain handoff (M4 step 4b) ─────────────────────────────────
+    // The Coordinator runs on a stable coordinator-class leader ("coord", oldest
+    // overall) while the catalog singleton lives on a WORKER (Class(Worker)
+    // anchor). That lets us change the oldest-worker — the anchor target — by
+    // joining an older worker, WITHOUT flipping the leader (so the leader-gated
+    // move handlers stay valid). No stop_sender is configured, so the stop
+    // warn-drops and we inject NotifySingletonStopped manually (as the bridge would).
+
+    fn make_coord_with_workers() -> (crate::System, Endpoint<Coordinator>) {
+        let system = crate::System::local();
+        let coord = NodeIdentity {
+            name: "coord".into(),
+            host: "127.0.0.1".into(),
+            port: 7000,
+            incarnation: 0, // oldest overall → stable leader
+        };
+        let local = coord.node_id_string();
+        let mut state =
+            CoordinatorState::new(&local, Box::new(LeastLoaded), Box::new(OldestNode::any()));
+        state.cluster_view.upsert_node(NodeInfo::new(
+            coord,
+            NodeClass::Coordinator,
+            HashMap::new(),
+        ));
+        // Two workers; w2 (incarnation 3) is older than w1 (5) → oldest worker.
+        for (name, port, inc) in [("w1", 7201u16, 5u64), ("w2", 7202, 3)] {
+            state.cluster_view.upsert_node(NodeInfo::new(
+                NodeIdentity {
+                    name: name.into(),
+                    host: "127.0.0.1".into(),
+                    port,
+                    incarnation: inc,
+                },
+                NodeClass::Worker,
+                HashMap::new(),
+            ));
+        }
+        let ep = system.start("coordinator", Coordinator, state);
+        (system, ep)
+    }
+
+    /// Join a worker older than w2 so the `Class(Worker)` anchor now resolves to
+    /// it (the leader, coord@0, is unaffected). Returns its node id.
+    async fn join_older_worker(coordinator: &Endpoint<Coordinator>) -> String {
+        let id = NodeIdentity {
+            name: "w0".into(),
+            host: "127.0.0.1".into(),
+            port: 7200,
+            incarnation: 1,
+        }
+        .node_id_string();
+        coordinator
+            .send(NotifyNodeJoined {
+                node_id: id.clone(),
+                info: SerializableNodeInfo {
+                    name: "w0".into(),
+                    host: "127.0.0.1".into(),
+                    port: 7200,
+                    incarnation: 1,
+                    class: NodeClass::Worker,
+                    metadata: HashMap::new(),
+                },
+            })
+            .await
+            .unwrap();
+        id
+    }
+
+    /// Start the catalog on the oldest worker (w2) and drive it to Active.
+    async fn start_active_catalog(coordinator: &Endpoint<Coordinator>) {
+        coordinator
+            .send_async(StartSingleton {
+                spec: SingletonSpec::new(
+                    "catalog",
+                    "app::Catalog",
+                    SingletonAnchor::Class(NodeClass::Worker),
+                ),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        coordinator
+            .send(NotifySpawnAck {
+                request_id: 0,
+                success: true,
+                error: None,
+            })
+            .await
+            .unwrap();
+    }
+
+    async fn get_catalog(coordinator: &Endpoint<Coordinator>) -> Option<SingletonOwnership> {
+        coordinator
+            .send(GetSingleton {
+                label: "catalog".into(),
+            })
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_singleton_graceful_move_drains_then_places_with_higher_term() {
+        let (_system, coordinator) = make_coord_with_workers();
+        start_active_catalog(&coordinator).await;
+        let w0 = join_older_worker(&coordinator).await;
+
+        // Graceful move: mint term 2 for the new owner, drain the old one.
+        coordinator
+            .send_async(MoveSingleton {
+                label: "catalog".into(),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+
+        let draining = get_catalog(&coordinator).await.unwrap();
+        assert_eq!(draining.phase, SingletonPhase::Draining);
+        assert!(
+            draining.owner_node_id.as_deref().unwrap().contains("w2"),
+            "ownership stays on the old owner while draining"
+        );
+        assert_eq!(draining.generation, SingletonGeneration { term: 1, seq: 0 });
+
+        // Old owner confirms stopped → place the new owner with the higher term.
+        coordinator
+            .send(NotifySingletonStopped {
+                label: "catalog".into(),
+                stopped_generation: SingletonGeneration { term: 1, seq: 0 },
+            })
+            .await
+            .unwrap();
+
+        let placing = get_catalog(&coordinator).await.unwrap();
+        assert_eq!(placing.owner_node_id.as_deref(), Some(w0.as_str()));
+        assert_eq!(placing.generation, SingletonGeneration { term: 2, seq: 0 });
+        assert_eq!(placing.phase, SingletonPhase::Starting);
+
+        // The new spawn acks (request_id 1) → Active.
+        coordinator
+            .send(NotifySpawnAck {
+                request_id: 1,
+                success: true,
+                error: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            get_catalog(&coordinator).await.unwrap().phase,
+            SingletonPhase::Active
+        );
+    }
+
+    #[tokio::test]
+    async fn test_singleton_graceful_move_ignores_stale_stopped_ack() {
+        let (_system, coordinator) = make_coord_with_workers();
+        start_active_catalog(&coordinator).await;
+        let w0 = join_older_worker(&coordinator).await;
+        coordinator
+            .send_async(MoveSingleton {
+                label: "catalog".into(),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+
+        // A stopped-ack with the wrong generation must NOT advance the handoff.
+        coordinator
+            .send(NotifySingletonStopped {
+                label: "catalog".into(),
+                stopped_generation: SingletonGeneration { term: 99, seq: 0 },
+            })
+            .await
+            .unwrap();
+        let still = get_catalog(&coordinator).await.unwrap();
+        assert_eq!(still.phase, SingletonPhase::Draining);
+        assert!(still.owner_node_id.as_deref().unwrap().contains("w2"));
+
+        // The matching ack advances it.
+        coordinator
+            .send(NotifySingletonStopped {
+                label: "catalog".into(),
+                stopped_generation: SingletonGeneration { term: 1, seq: 0 },
+            })
+            .await
+            .unwrap();
+        let placing = get_catalog(&coordinator).await.unwrap();
+        assert_eq!(placing.owner_node_id.as_deref(), Some(w0.as_str()));
+        assert_eq!(placing.generation, SingletonGeneration { term: 2, seq: 0 });
+    }
+
+    #[tokio::test]
+    async fn test_singleton_graceful_teardown_removes_after_drain() {
+        let (_system, coordinator) = make_coord_with_workers();
+        start_active_catalog(&coordinator).await;
+
+        coordinator
+            .send(StopSingleton {
+                label: "catalog".into(),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            get_catalog(&coordinator).await.unwrap().phase,
+            SingletonPhase::Draining
+        );
+
+        coordinator
+            .send(NotifySingletonStopped {
+                label: "catalog".into(),
+                stopped_generation: SingletonGeneration { term: 1, seq: 0 },
+            })
+            .await
+            .unwrap();
+        assert!(
+            get_catalog(&coordinator).await.is_none(),
+            "a torn-down singleton is forgotten"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_singleton_move_is_noop_when_anchor_unchanged() {
+        let (_system, coordinator) = make_coord_with_workers();
+        start_active_catalog(&coordinator).await;
+
+        // Oldest worker is still w2 → move resolves to the current owner → no-op.
+        coordinator
+            .send_async(MoveSingleton {
+                label: "catalog".into(),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        let after = get_catalog(&coordinator).await.unwrap();
+        assert_eq!(after.phase, SingletonPhase::Active);
+        assert_eq!(after.generation, SingletonGeneration { term: 1, seq: 0 });
+        assert!(after.owner_node_id.as_deref().unwrap().contains("w2"));
+    }
+
+    #[tokio::test]
+    async fn test_singleton_drain_timeout_force_proceeds() {
+        let (_system, coordinator) = make_coord_with_workers();
+        coordinator
+            .send_async(StartSingleton {
+                spec: SingletonSpec::new(
+                    "catalog",
+                    "app::Catalog",
+                    SingletonAnchor::Class(NodeClass::Worker),
+                )
+                .with_drain_timeout(Duration::from_secs(30)),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        coordinator
+            .send(NotifySpawnAck {
+                request_id: 0,
+                success: true,
+                error: None,
+            })
+            .await
+            .unwrap();
+        let w0 = join_older_worker(&coordinator).await;
+        coordinator
+            .send_async(MoveSingleton {
+                label: "catalog".into(),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Simulate the drain timer firing (old owner never acked) → force-proceed.
+        coordinator
+            .send(SingletonDrainTimeout {
+                label: "catalog".into(),
+                drained_generation: SingletonGeneration { term: 1, seq: 0 },
+            })
+            .await
+            .unwrap();
+
+        let placing = get_catalog(&coordinator).await.unwrap();
+        assert_eq!(placing.owner_node_id.as_deref(), Some(w0.as_str()));
+        assert_eq!(placing.generation, SingletonGeneration { term: 2, seq: 0 });
+        assert_eq!(placing.phase, SingletonPhase::Starting);
     }
 }

--- a/murmer/src/app/mod.rs
+++ b/murmer/src/app/mod.rs
@@ -14,6 +14,7 @@
 //! - [`election`] — Pluggable leader election (default: OldestNode)
 //! - [`coordinator`] — The Coordinator actor that orchestrates placement
 //! - [`bridge`] — Cluster event bridge connecting cluster layer to Coordinator
+//! - [`singleton`] — Cluster singletons (exactly-one, anchor-pinned, fenced handoff)
 //! - [`error`] — Error types
 
 pub mod bridge;
@@ -22,5 +23,6 @@ pub mod election;
 pub mod error;
 pub mod node_info;
 pub mod placement;
+pub mod singleton;
 pub(crate) mod spawn_sender;
 pub mod spec;

--- a/murmer/src/app/placement.rs
+++ b/murmer/src/app/placement.rs
@@ -9,7 +9,7 @@
 //! | Strategy | Behavior |
 //! |----------|----------|
 //! | [`LeastLoaded`] | Fewest running actors wins |
-//! | [`Random`] | Uniform random selection |
+//! | [`RandomPlacement`] | Uniform random selection |
 //! | [`Pinned`] | Always prefer a specific node |
 //!
 //! # Custom strategies

--- a/murmer/src/app/placement.rs
+++ b/murmer/src/app/placement.rs
@@ -86,10 +86,12 @@ pub fn select_node(
 
     for node in view.alive_nodes() {
         // Filter: must satisfy placement constraints
-        if !spec
-            .placement
-            .is_satisfied_by(&node.class, &node.metadata, &node.running_actors)
-        {
+        if !spec.placement.is_satisfied_by(
+            &node.node_id(),
+            &node.class,
+            &node.metadata,
+            &node.running_actors,
+        ) {
             continue;
         }
 
@@ -278,5 +280,82 @@ mod tests {
             "expected beta, got {}",
             decision.node_id
         );
+    }
+
+    #[test]
+    fn test_colocate_with_pins_to_anchor_node() {
+        // beta already runs the anchor "writer/c1"; alpha is emptier (would win
+        // LeastLoaded) but does not run the anchor, so colocate_with must force beta.
+        let view = make_view(vec![
+            make_node("alpha", 1, vec![]),
+            make_node("beta", 2, vec!["writer/c1".into()]),
+        ]);
+        let spec = ActorSpec::new("reader/c1/0", "app::Reader").with_constraints(
+            crate::app::spec::PlacementConstraints {
+                colocate_with: Some("writer/c1".into()),
+                ..Default::default()
+            },
+        );
+        let decision = select_node(&LeastLoaded, &spec, &view).unwrap();
+        assert!(
+            decision.node_id.contains("beta"),
+            "colocate_with should pin to the anchor's node (beta), got {}",
+            decision.node_id
+        );
+    }
+
+    #[test]
+    fn test_colocate_with_no_anchor_returns_none() {
+        // No node runs the anchor → hard filter yields NoEligibleNodes (never
+        // silently relocates), unlike the soft Pinned strategy.
+        let view = make_view(vec![
+            make_node("alpha", 1, vec![]),
+            make_node("beta", 2, vec![]),
+        ]);
+        let spec = ActorSpec::new("reader/c1/0", "app::Reader").with_constraints(
+            crate::app::spec::PlacementConstraints {
+                colocate_with: Some("writer/c1".into()),
+                ..Default::default()
+            },
+        );
+        assert!(select_node(&LeastLoaded, &spec, &view).is_none());
+    }
+
+    #[test]
+    fn test_required_node_id_pins_exactly_or_none() {
+        let alpha = make_node("alpha", 1, vec![]); // emptier → LeastLoaded would pick it
+        let beta = make_node("beta", 2, vec!["x".into()]);
+        let beta_id = beta.node_id();
+        let view = make_view(vec![alpha, beta]);
+
+        // Hard-pin to beta: chosen even though alpha is less loaded.
+        let spec = ActorSpec::new("w/0", "app::Worker").with_constraints(
+            crate::app::spec::PlacementConstraints {
+                required_node_id: Some(beta_id.clone()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            select_node(&LeastLoaded, &spec, &view).unwrap().node_id,
+            beta_id
+        );
+
+        // Pin to a node that does not exist → NoEligibleNodes (no silent relocate).
+        let spec_missing = ActorSpec::new("w/1", "app::Worker").with_constraints(
+            crate::app::spec::PlacementConstraints {
+                required_node_id: Some("ghost@127.0.0.1:9999#0".into()),
+                ..Default::default()
+            },
+        );
+        assert!(select_node(&LeastLoaded, &spec_missing, &view).is_none());
+    }
+
+    #[test]
+    fn test_default_constraints_unchanged_backward_compat() {
+        // Empty constraints (the default) must still place anywhere — the new
+        // fields are additive Option/None and must not regress existing behavior.
+        let view = make_view(vec![make_node("alpha", 1, vec![])]);
+        let spec = ActorSpec::new("w/0", "app::Worker");
+        assert!(select_node(&LeastLoaded, &spec, &view).is_some());
     }
 }

--- a/murmer/src/app/singleton.rs
+++ b/murmer/src/app/singleton.rs
@@ -1,0 +1,473 @@
+//! Cluster singletons — exactly-one, anchor-pinned, fenced-handoff actors.
+//!
+//! A *cluster singleton* is an actor of which there must be **exactly one**
+//! instance across the whole cluster (e.g. a catalog owner, a sequence minter).
+//! It generalizes the Coordinator's own leader election + `is_leader` into a
+//! reusable primitive: the singleton is pinned to an [`SingletonAnchor`]
+//! (the leader, the oldest node of a class, or a specific node), and ownership
+//! moves between nodes through a **fenced** stop-old → await-stopped → start-new
+//! handoff so that two instances never run concurrently.
+//!
+//! # The fence: `(term, seq)` generations
+//!
+//! Every ownership grant carries a monotone [`SingletonGeneration`]. It is a
+//! lexicographic `(term, seq)` pair (an FDB-style *recovery epoch*):
+//!
+//! - `term` bumps **once per ownership change** (node departure, anchor move,
+//!   leader change). This is the recovery epoch.
+//! - `seq` is a per-term monotone counter for repeated grants to the *same*
+//!   owner (liveness renew / idempotent re-place).
+//!
+//! Because a successor always bumps `term` during handoff, a stale ex-owner
+//! necessarily holds a strictly-lower `(term, seq)` than its successor. The
+//! generation packs into a single `u64` ([`SingletonGeneration::packed`]) so a
+//! downstream fence that compares a single integer (e.g. appdata's on-disk
+//! `HEAD.writer_gen` advance-or-reject) fences the stale owner with **no change
+//! to that comparison** — only *who mints* the generation changes.
+//!
+//! # Pluggable [`GenerationSource`]
+//!
+//! Minting is behind the [`GenerationSource`] trait so the authoritative store
+//! is swappable: a single-owner external store (e.g. appdata's catalog) today,
+//! a consensus-minted source later — without touching the downstream fence.
+//! The default [`CoordinatorGenerationSource`] keeps generations in RAM and is
+//! suitable only for single-node deployments and tests (it is **not** durable
+//! across a Coordinator restart).
+//!
+//! Enable with `murmer = { features = ["app"] }`.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::app::election::{LeaderElection, OldestNode};
+use crate::app::node_info::ClusterView;
+use crate::cluster::config::NodeClass;
+
+// =============================================================================
+// SINGLETON ANCHOR
+// =============================================================================
+
+/// Where the unique instance is pinned. Generalizes the Coordinator's own
+/// `is_leader` notion into per-singleton ownership.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SingletonAnchor {
+    /// Owner = whatever `election.elect(&cluster_view)` currently points at —
+    /// the generalization of the Coordinator's own leader.
+    Leader,
+    /// Owner = oldest alive node of this class (reuses `OldestNode::with_class`).
+    Class(NodeClass),
+    /// Owner = exactly this node id (maps to `PlacementConstraints.required_node_id`).
+    Node(String),
+}
+
+// =============================================================================
+// SINGLETON GENERATION — the fence token
+// =============================================================================
+
+/// Monotone fence token minted per successful ownership grant.
+///
+/// Lexicographic `(term, seq)`: `term` bumps once per ownership change (recovery
+/// epoch, FDB-style); `seq` is a per-term monotone counter for repeated claims
+/// under one owner. A stale ex-owner necessarily holds a strictly-lower
+/// `(term, seq)` than any successor.
+///
+/// The derived [`Ord`] compares `term` first, then `seq` (field declaration
+/// order) — i.e. exactly lexicographic order.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct SingletonGeneration {
+    /// Recovery epoch — bumps once per ownership change.
+    pub term: u64,
+    /// Per-term monotone re-grant counter.
+    pub seq: u64,
+}
+
+impl SingletonGeneration {
+    /// Pack into a single `u64` that a downstream fence can compare numerically:
+    /// `term` in the high 32 bits, `seq` in the low 32 bits. While both fields
+    /// stay within `u32` range, numeric comparison of the packed value equals
+    /// lexicographic comparison of `(term, seq)`.
+    pub fn packed(self) -> u64 {
+        (self.term << 32) | (self.seq & 0xFFFF_FFFF)
+    }
+
+    /// Inverse of [`packed`](Self::packed).
+    pub fn from_packed(packed: u64) -> Self {
+        Self {
+            term: packed >> 32,
+            seq: packed & 0xFFFF_FFFF,
+        }
+    }
+}
+
+// =============================================================================
+// SINGLETON SPEC + OWNERSHIP
+// =============================================================================
+
+/// Declarative request to run exactly one instance of an actor cluster-wide.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SingletonSpec {
+    /// Stable singleton label (e.g. `"catalog"`).
+    pub label: String,
+    /// `SpawnRegistry` key identifying the actor type to spawn.
+    pub actor_type_name: String,
+    /// Serialized initial state (`MigratableActor` boot bytes).
+    pub initial_state: Vec<u8>,
+    /// Where the unique instance is pinned.
+    pub anchor: SingletonAnchor,
+    /// How long to await the old instance's stopped-ack before force-proceeding
+    /// with the new owner. `None` = wait indefinitely (safest for writers — a
+    /// stuck old owner blocks failover but can never double-write).
+    pub drain_timeout: Option<Duration>,
+}
+
+impl SingletonSpec {
+    /// Create a spec with no drain timeout (wait indefinitely on handoff).
+    pub fn new(
+        label: impl Into<String>,
+        actor_type_name: impl Into<String>,
+        anchor: SingletonAnchor,
+    ) -> Self {
+        Self {
+            label: label.into(),
+            actor_type_name: actor_type_name.into(),
+            initial_state: Vec::new(),
+            anchor,
+            drain_timeout: None,
+        }
+    }
+
+    /// Set the serialized initial (boot) state.
+    pub fn with_state(mut self, state: Vec<u8>) -> Self {
+        self.initial_state = state;
+        self
+    }
+
+    /// Set a bounded drain timeout for the handoff await-stopped barrier.
+    pub fn with_drain_timeout(mut self, timeout: Duration) -> Self {
+        self.drain_timeout = Some(timeout);
+        self
+    }
+}
+
+/// Phase of a singleton's lifecycle during (re)placement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SingletonPhase {
+    /// The owner is running and serving.
+    Active,
+    /// Handoff in progress: the old owner has been asked to stop and we are
+    /// awaiting its stopped-ack (or the drain timeout) before starting the new.
+    Draining,
+    /// The old owner has stopped; the new owner is being spawned.
+    Starting,
+}
+
+/// Authoritative ownership record for a singleton.
+///
+/// The durable copy lives in the [`GenerationSource`]'s backing store (for the
+/// default it is RAM; for appdata it is the catalog — one linearization point).
+/// The Coordinator holds this as a soft, rebuildable cache.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SingletonOwnership {
+    /// The singleton label this record is for.
+    pub label: String,
+    /// The node currently granted ownership, or `None` while handing off.
+    pub owner_node_id: Option<String>,
+    /// The current granted generation.
+    pub generation: SingletonGeneration,
+    /// The current lifecycle phase.
+    pub phase: SingletonPhase,
+}
+
+// =============================================================================
+// OWNER RESOLUTION
+// =============================================================================
+
+/// Resolve the node that should own a singleton given its anchor and the
+/// current cluster view. Returns `None` if no eligible node exists.
+///
+/// - [`SingletonAnchor::Leader`] reuses the supplied [`LeaderElection`].
+/// - [`SingletonAnchor::Class`] reuses [`OldestNode`] ordering restricted to
+///   that class (so it matches how the Coordinator itself would elect within a
+///   class).
+/// - [`SingletonAnchor::Node`] pins exactly to that node, but only while it is
+///   alive in the view.
+pub fn resolve_owner(
+    anchor: &SingletonAnchor,
+    view: &ClusterView,
+    election: &dyn LeaderElection,
+) -> Option<String> {
+    match anchor {
+        SingletonAnchor::Leader => election.elect(view),
+        SingletonAnchor::Class(class) => OldestNode::with_class(class.clone()).elect(view),
+        SingletonAnchor::Node(node_id) => view
+            .alive_nodes()
+            .find(|n| &n.node_id() == node_id)
+            .map(|n| n.node_id()),
+    }
+}
+
+// =============================================================================
+// GENERATION SOURCE
+// =============================================================================
+
+/// Pluggable authority that mints and persists [`SingletonGeneration`]s.
+///
+/// Keeping minting behind a trait lets the authoritative store be swapped — a
+/// single-owner external store (e.g. appdata's catalog, today) or a
+/// consensus-minted source (later) — **without** changing the downstream fence
+/// that compares the packed generation.
+///
+/// Implementations must guarantee that, for a given `label`, every successful
+/// `claim_term` returns a strictly greater `term` than any previously returned
+/// generation, and that `seq` is strictly increasing within a term.
+#[async_trait::async_trait]
+pub trait GenerationSource: Send + Sync {
+    /// Begin a new ownership epoch for `label` granted to `owner_node_id`:
+    /// bump `term`, reset `seq` to 0, and persist `(owner, term, 0)`. Returns
+    /// the newly minted generation.
+    async fn claim_term(
+        &self,
+        label: &str,
+        owner_node_id: &str,
+    ) -> Result<SingletonGeneration, String>;
+
+    /// Re-grant to the current owner within the current term (liveness renew /
+    /// idempotent re-place): bump `seq`. Returns the new generation.
+    async fn claim_seq(&self, label: &str) -> Result<SingletonGeneration, String>;
+
+    /// Read the current authoritative ownership for `label` (used for
+    /// cold-start rebuild after a Coordinator restart). `None` if never claimed.
+    async fn current(&self, label: &str) -> Result<Option<SingletonOwnership>, String>;
+}
+
+/// Default in-RAM [`GenerationSource`].
+///
+/// Suitable for single-node deployments and tests **only** — it is not durable
+/// across a Coordinator restart (term/seq reset to zero), which would break
+/// monotonicity in a multi-node write deployment. Production multi-node use
+/// must inject a durable source (e.g. appdata's catalog-backed one).
+#[derive(Debug, Default)]
+pub struct CoordinatorGenerationSource {
+    state: Mutex<HashMap<String, SingletonOwnership>>,
+}
+
+impl CoordinatorGenerationSource {
+    /// Create an empty in-RAM generation source.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait::async_trait]
+impl GenerationSource for CoordinatorGenerationSource {
+    async fn claim_term(
+        &self,
+        label: &str,
+        owner_node_id: &str,
+    ) -> Result<SingletonGeneration, String> {
+        let mut state = self.state.lock().expect("generation source mutex poisoned");
+        // term 0 is reserved for "never claimed"; first grant is term 1.
+        let term = state.get(label).map(|o| o.generation.term + 1).unwrap_or(1);
+        let generation = SingletonGeneration { term, seq: 0 };
+        state.insert(
+            label.to_string(),
+            SingletonOwnership {
+                label: label.to_string(),
+                owner_node_id: Some(owner_node_id.to_string()),
+                generation,
+                phase: SingletonPhase::Active,
+            },
+        );
+        Ok(generation)
+    }
+
+    async fn claim_seq(&self, label: &str) -> Result<SingletonGeneration, String> {
+        let mut state = self.state.lock().expect("generation source mutex poisoned");
+        match state.get_mut(label) {
+            Some(ownership) => {
+                ownership.generation.seq += 1;
+                Ok(ownership.generation)
+            }
+            None => Err(format!(
+                "claim_seq before claim_term for singleton '{label}'"
+            )),
+        }
+    }
+
+    async fn current(&self, label: &str) -> Result<Option<SingletonOwnership>, String> {
+        Ok(self
+            .state
+            .lock()
+            .expect("generation source mutex poisoned")
+            .get(label)
+            .cloned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::node_info::NodeInfo;
+    use crate::cluster::config::NodeIdentity;
+
+    fn make_node(name: &str, incarnation: u64, class: NodeClass) -> NodeInfo {
+        NodeInfo::new(
+            NodeIdentity {
+                name: name.into(),
+                host: "127.0.0.1".into(),
+                port: 7100,
+                incarnation,
+            },
+            class,
+            HashMap::new(),
+        )
+    }
+
+    fn view_of(nodes: Vec<NodeInfo>) -> ClusterView {
+        let mut view = ClusterView::new();
+        for n in nodes {
+            view.upsert_node(n);
+        }
+        view
+    }
+
+    #[test]
+    fn test_packed_preserves_lexicographic_order_across_u32_boundary() {
+        // The whole point of the fence: a higher term ALWAYS outranks any seq.
+        let lo = SingletonGeneration {
+            term: 0,
+            seq: u32::MAX as u64,
+        };
+        let hi = SingletonGeneration { term: 1, seq: 0 };
+        // Ord (lexicographic) and packed numeric compare must agree.
+        assert!(hi > lo);
+        assert!(hi.packed() > lo.packed());
+        assert_eq!(hi.packed(), 1u64 << 32);
+        assert_eq!(lo.packed(), u32::MAX as u64);
+    }
+
+    #[test]
+    fn test_packed_roundtrip() {
+        let g = SingletonGeneration { term: 7, seq: 42 };
+        assert_eq!(SingletonGeneration::from_packed(g.packed()), g);
+    }
+
+    #[test]
+    fn test_ord_is_term_major() {
+        let a = SingletonGeneration { term: 2, seq: 0 };
+        let b = SingletonGeneration {
+            term: 2,
+            seq: 1_000_000,
+        };
+        let c = SingletonGeneration { term: 3, seq: 0 };
+        assert!(a < b); // same term, higher seq
+        assert!(b < c); // higher term beats any seq
+        assert!(a < c);
+    }
+
+    #[test]
+    fn test_resolve_owner_leader_matches_election() {
+        let view = view_of(vec![
+            make_node("gamma", 300, NodeClass::Worker),
+            make_node("alpha", 100, NodeClass::Worker),
+            make_node("beta", 200, NodeClass::Worker),
+        ]);
+        let election = OldestNode::any();
+        let owner = resolve_owner(&SingletonAnchor::Leader, &view, &election).unwrap();
+        assert_eq!(owner, election.elect(&view).unwrap());
+        assert!(owner.contains("alpha"), "oldest should win, got {owner}");
+    }
+
+    #[test]
+    fn test_resolve_owner_class_picks_oldest_of_class() {
+        let view = view_of(vec![
+            // alpha is oldest overall but a Worker
+            make_node("alpha", 100, NodeClass::Worker),
+            // beta is younger but the oldest Coordinator
+            make_node("beta", 200, NodeClass::Coordinator),
+            make_node("delta", 300, NodeClass::Coordinator),
+        ]);
+        let election = OldestNode::any();
+        let owner = resolve_owner(
+            &SingletonAnchor::Class(NodeClass::Coordinator),
+            &view,
+            &election,
+        )
+        .unwrap();
+        assert!(
+            owner.contains("beta"),
+            "oldest Coordinator should win, got {owner}"
+        );
+    }
+
+    #[test]
+    fn test_resolve_owner_node_pins_exactly_and_requires_alive() {
+        let target = make_node("beta", 200, NodeClass::Worker);
+        let target_id = target.node_id();
+        let view = view_of(vec![make_node("alpha", 100, NodeClass::Worker), target]);
+        let election = OldestNode::any();
+
+        // Pin to an alive node → exactly that node, even though alpha is older.
+        let owner =
+            resolve_owner(&SingletonAnchor::Node(target_id.clone()), &view, &election).unwrap();
+        assert_eq!(owner, target_id);
+
+        // Pin to a non-existent node → None (never silently relocates).
+        assert!(
+            resolve_owner(
+                &SingletonAnchor::Node("ghost@127.0.0.1:9999#0".into()),
+                &view,
+                &election,
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn test_resolve_owner_node_pin_rejects_dead_node() {
+        let target = make_node("beta", 200, NodeClass::Worker);
+        let target_id = target.node_id();
+        let mut view = view_of(vec![make_node("alpha", 100, NodeClass::Worker), target]);
+        view.mark_failed(&target_id);
+        let election = OldestNode::any();
+        assert!(resolve_owner(&SingletonAnchor::Node(target_id), &view, &election).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_ram_source_claim_term_increments_and_resets_seq() {
+        let src = CoordinatorGenerationSource::new();
+
+        let g1 = src.claim_term("catalog", "node-a").await.unwrap();
+        assert_eq!(g1, SingletonGeneration { term: 1, seq: 0 });
+
+        // Re-grant to same owner bumps seq within the term.
+        let g1b = src.claim_seq("catalog").await.unwrap();
+        assert_eq!(g1b, SingletonGeneration { term: 1, seq: 1 });
+
+        // New ownership epoch bumps term and resets seq, strictly outranking g1b.
+        let g2 = src.claim_term("catalog", "node-b").await.unwrap();
+        assert_eq!(g2, SingletonGeneration { term: 2, seq: 0 });
+        assert!(g2 > g1b);
+
+        // current() reflects the latest grant.
+        let cur = src.current("catalog").await.unwrap().unwrap();
+        assert_eq!(cur.owner_node_id.as_deref(), Some("node-b"));
+        assert_eq!(cur.generation, g2);
+        assert_eq!(cur.phase, SingletonPhase::Active);
+    }
+
+    #[tokio::test]
+    async fn test_ram_source_claim_seq_before_term_errors() {
+        let src = CoordinatorGenerationSource::new();
+        assert!(src.claim_seq("never-claimed").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_ram_source_current_unknown_is_none() {
+        let src = CoordinatorGenerationSource::new();
+        assert!(src.current("nope").await.unwrap().is_none());
+    }
+}

--- a/murmer/src/app/spawn_sender.rs
+++ b/murmer/src/app/spawn_sender.rs
@@ -39,3 +39,36 @@ impl SpawnSender {
         }
     }
 }
+
+/// A request to gracefully stop a cluster singleton instance on a node, so
+/// ownership can hand off.
+pub(crate) struct SingletonStopRequest {
+    /// The node currently running the singleton instance to stop.
+    pub target_node_id: String,
+    /// The singleton label.
+    pub label: String,
+    /// The packed `(term, seq)` the owner was granted — echoed in the ack so a
+    /// superseded owner's late stop is ignored.
+    pub generation: u64,
+}
+
+/// A channel-based handle the Coordinator uses to request a singleton stop
+/// (the inner half of the graceful drain handoff).
+///
+/// Not public — created internally by [`crate::app::bridge::start_coordinator`].
+pub(crate) struct SingletonStopSender {
+    tx: mpsc::UnboundedSender<SingletonStopRequest>,
+}
+
+impl SingletonStopSender {
+    pub fn new(tx: mpsc::UnboundedSender<SingletonStopRequest>) -> Self {
+        Self { tx }
+    }
+
+    /// Queue a stop request for the node currently running the singleton.
+    pub fn send_stop(&self, request: SingletonStopRequest) {
+        if self.tx.send(request).is_err() {
+            tracing::warn!("Singleton stop sender channel closed — stop request dropped");
+        }
+    }
+}

--- a/murmer/src/app/spec.rs
+++ b/murmer/src/app/spec.rs
@@ -61,12 +61,28 @@ pub struct PlacementConstraints {
     /// Actor must not be placed on a node already running actors with these labels.
     /// Useful for spreading replicas across failure domains.
     pub anti_affinity_labels: Vec<String>,
+    /// HARD positive affinity: the node must ALREADY be running an actor with
+    /// this label. The inverse of `anti_affinity_labels` — use it to co-locate
+    /// a member with an anchor (e.g. pin a reader to the node hosting its
+    /// writer). Unlike the soft `Pinned` strategy this is a filter, so if no
+    /// node runs the anchor the spec gets `NoEligibleNodes` rather than landing
+    /// elsewhere. `None` = no co-location requirement.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub colocate_with: Option<String>,
+    /// HARD pin to exactly this node id. If that node is not alive/eligible the
+    /// spec gets `NoEligibleNodes` (it is NEVER silently relocated — that is the
+    /// difference from the soft `Pinned` strategy). `None` = no node pin.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub required_node_id: Option<String>,
 }
 
 impl PlacementConstraints {
     /// Check if a node satisfies all constraints.
+    ///
+    /// `node_id` is the candidate node's id, needed for `required_node_id`.
     pub fn is_satisfied_by(
         &self,
+        node_id: &str,
         node_class: &NodeClass,
         node_metadata: &HashMap<String, String>,
         running_actors: &[String],
@@ -84,11 +100,25 @@ impl PlacementConstraints {
             }
         }
 
-        // Check anti-affinity
+        // Check anti-affinity (repel)
         for label in &self.anti_affinity_labels {
             if running_actors.contains(label) {
                 return false;
             }
+        }
+
+        // Check positive affinity (attract): node must already run the anchor.
+        if let Some(anchor) = &self.colocate_with
+            && !running_actors.iter().any(|l| l == anchor)
+        {
+            return false;
+        }
+
+        // Check hard node pin: must be exactly this node.
+        if let Some(required) = &self.required_node_id
+            && node_id != required
+        {
+            return false;
         }
 
         true
@@ -153,10 +183,13 @@ impl ActorSpec {
 mod tests {
     use super::*;
 
+    // A placeholder node id for constraints that don't exercise `required_node_id`.
+    const ANY_NODE: &str = "node-a@127.0.0.1:7100#1";
+
     #[test]
     fn test_placement_constraints_empty_allows_all() {
         let constraints = PlacementConstraints::default();
-        assert!(constraints.is_satisfied_by(&NodeClass::Worker, &HashMap::new(), &[],));
+        assert!(constraints.is_satisfied_by(ANY_NODE, &NodeClass::Worker, &HashMap::new(), &[]));
     }
 
     #[test]
@@ -165,8 +198,8 @@ mod tests {
             required_classes: vec![NodeClass::Worker],
             ..Default::default()
         };
-        assert!(constraints.is_satisfied_by(&NodeClass::Worker, &HashMap::new(), &[]));
-        assert!(!constraints.is_satisfied_by(&NodeClass::Edge, &HashMap::new(), &[]));
+        assert!(constraints.is_satisfied_by(ANY_NODE, &NodeClass::Worker, &HashMap::new(), &[]));
+        assert!(!constraints.is_satisfied_by(ANY_NODE, &NodeClass::Edge, &HashMap::new(), &[]));
     }
 
     #[test]
@@ -178,9 +211,9 @@ mod tests {
         let good_meta: HashMap<String, String> = [("region".into(), "us-west".into())].into();
         let bad_meta: HashMap<String, String> = [("region".into(), "eu-west".into())].into();
 
-        assert!(constraints.is_satisfied_by(&NodeClass::Worker, &good_meta, &[]));
-        assert!(!constraints.is_satisfied_by(&NodeClass::Worker, &bad_meta, &[]));
-        assert!(!constraints.is_satisfied_by(&NodeClass::Worker, &HashMap::new(), &[]));
+        assert!(constraints.is_satisfied_by(ANY_NODE, &NodeClass::Worker, &good_meta, &[]));
+        assert!(!constraints.is_satisfied_by(ANY_NODE, &NodeClass::Worker, &bad_meta, &[]));
+        assert!(!constraints.is_satisfied_by(ANY_NODE, &NodeClass::Worker, &HashMap::new(), &[]));
     }
 
     #[test]
@@ -190,11 +223,13 @@ mod tests {
             ..Default::default()
         };
         assert!(constraints.is_satisfied_by(
+            ANY_NODE,
             &NodeClass::Worker,
             &HashMap::new(),
             &["worker/1".into()],
         ));
         assert!(!constraints.is_satisfied_by(
+            ANY_NODE,
             &NodeClass::Worker,
             &HashMap::new(),
             &["replica/0".into(), "worker/1".into()],

--- a/murmer/src/cluster/framing.rs
+++ b/murmer/src/cluster/framing.rs
@@ -36,6 +36,18 @@ pub enum ControlMessage {
     SpawnAckOk { request_id: u64, label: String },
     /// Node reports actor spawn failure.
     SpawnAckErr { request_id: u64, error: String },
+    /// Coordinator instructs the current owner node to stop a cluster singleton
+    /// so ownership can hand off. `generation` is the packed `(term, seq)` the
+    /// owner was granted, echoed back in the ack so a superseded owner's late
+    /// ack can be ignored.
+    StopSingleton { label: String, generation: u64 },
+    /// Owner node confirms the singleton has fully stopped (its `DeregisterGuard`
+    /// fired). This is the cross-node await-stopped barrier — the analog of a
+    /// local drain — that must complete before the new owner is started.
+    SingletonStoppedAck {
+        label: String,
+        stopped_generation: u64,
+    },
 }
 
 /// A request to spawn an actor on a remote node.
@@ -53,6 +65,16 @@ pub struct SpawnRequest {
     pub actor_type_name: String,
     /// Serialized initial state (via MigratableActor).
     pub initial_state: Vec<u8>,
+    /// Packed `(term, seq)` placement generation when this spawn is for a fenced
+    /// cluster singleton, threaded opaquely to the spawning node so it can stamp
+    /// the actor's boot config. `None` for ordinary (non-singleton) spawns.
+    ///
+    /// Note: `#[serde(default)]` is for forward-friendliness with self-describing
+    /// formats; the wire codec is bincode (positional), and all cluster nodes run
+    /// the same `PROTOCOL_VERSION`, so genuinely-older byte streams are never
+    /// decoded here — `SpawnRequest` is wire-only and never persisted.
+    #[serde(default)]
+    pub singleton_generation: Option<u64>,
 }
 
 /// The handshake payload exchanged when two nodes first connect.
@@ -378,6 +400,53 @@ mod tests {
         let decoded: ControlMessage = decode_message(payload).unwrap();
 
         assert!(matches!(decoded, ControlMessage::Ping));
+    }
+
+    #[test]
+    fn test_spawn_request_roundtrip_with_and_without_generation() {
+        // Same-version round-trip for both the singleton (Some) and ordinary
+        // (None) spawn shapes. (bincode is positional, so this is not a
+        // cross-version test — all nodes share PROTOCOL_VERSION.)
+        for generation in [None, Some((1u64 << 32) | 7)] {
+            let msg = ControlMessage::SpawnActor(SpawnRequest {
+                request_id: 42,
+                label: "catalog".into(),
+                actor_type_name: "app::Catalog".into(),
+                initial_state: vec![1, 2, 3],
+                singleton_generation: generation,
+            });
+            let frame = encode_message(&msg).unwrap();
+            let decoded: ControlMessage = decode_message(&frame[4..]).unwrap();
+            match decoded {
+                ControlMessage::SpawnActor(req) => {
+                    assert_eq!(req.request_id, 42);
+                    assert_eq!(req.singleton_generation, generation);
+                }
+                other => panic!("expected SpawnActor, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_singleton_stop_and_ack_roundtrip() {
+        let packed = (3u64 << 32) | 5;
+        let stop = ControlMessage::StopSingleton {
+            label: "catalog".into(),
+            generation: packed,
+        };
+        let decoded: ControlMessage = decode_message(&encode_message(&stop).unwrap()[4..]).unwrap();
+        assert!(
+            matches!(decoded, ControlMessage::StopSingleton { label, generation } if label == "catalog" && generation == packed)
+        );
+
+        let ack = ControlMessage::SingletonStoppedAck {
+            label: "catalog".into(),
+            stopped_generation: packed,
+        };
+        let decoded: ControlMessage = decode_message(&encode_message(&ack).unwrap()[4..]).unwrap();
+        assert!(
+            matches!(decoded, ControlMessage::SingletonStoppedAck { label, stopped_generation } if label == "catalog" && stopped_generation == packed)
+        );
     }
 
     #[test]

--- a/murmer/src/cluster/membership.rs
+++ b/murmer/src/cluster/membership.rs
@@ -51,6 +51,14 @@ pub enum ClusterEvent {
         request_id: u64,
         error: String,
     },
+    /// A cluster singleton's owner confirmed it has stopped (forwarded from the
+    /// SingletonStoppedAck control message). `stopped_generation` is the packed
+    /// `(term, seq)` the owner was running, so the Coordinator can ignore a late
+    /// ack from a superseded owner. This is the cross-node await-stopped barrier.
+    SingletonStopped {
+        label: String,
+        stopped_generation: u64,
+    },
 }
 
 // =============================================================================

--- a/murmer/src/cluster/mod.rs
+++ b/murmer/src/cluster/mod.rs
@@ -602,13 +602,24 @@ fn spawn_event_loop(
                             });
                         }
                         ControlMessage::StopSingleton { ref label, generation } => {
-                            // TODO(M4 step 4): stop the locally-owned singleton via the
-                            // receptionist, then on its DeregisterGuard firing send a
-                            // SingletonStoppedAck back to `node_id`. Placeholder until the
-                            // fenced handoff state machine lands.
-                            tracing::warn!(
-                                "StopSingleton from {node_id} for {label} (gen={generation}) — handler not yet wired (M4 step 4)"
+                            // Cross-node drain: the Coordinator asked this node to
+                            // stop the singleton instance it owns. Signal the local
+                            // stop and ack. The successor is placed with a strictly
+                            // higher generation, so a briefly-lingering old instance
+                            // is fenced on its next write.
+                            tracing::info!(
+                                "StopSingleton from {node_id} for {label} (gen={generation}) — stopping local instance"
                             );
+                            receptionist.stop(label);
+                            let _ = transport
+                                .send_control(
+                                    &node_id,
+                                    ControlMessage::SingletonStoppedAck {
+                                        label: label.clone(),
+                                        stopped_generation: generation,
+                                    },
+                                )
+                                .await;
                         }
                         ControlMessage::SingletonStoppedAck { ref label, stopped_generation } => {
                             tracing::info!(

--- a/murmer/src/cluster/mod.rs
+++ b/murmer/src/cluster/mod.rs
@@ -601,6 +601,24 @@ fn spawn_event_loop(
                                 error: error.clone(),
                             });
                         }
+                        ControlMessage::StopSingleton { ref label, generation } => {
+                            // TODO(M4 step 4): stop the locally-owned singleton via the
+                            // receptionist, then on its DeregisterGuard firing send a
+                            // SingletonStoppedAck back to `node_id`. Placeholder until the
+                            // fenced handoff state machine lands.
+                            tracing::warn!(
+                                "StopSingleton from {node_id} for {label} (gen={generation}) — handler not yet wired (M4 step 4)"
+                            );
+                        }
+                        ControlMessage::SingletonStoppedAck { ref label, stopped_generation } => {
+                            tracing::info!(
+                                "SingletonStoppedAck from {node_id}: label={label}, gen={stopped_generation}"
+                            );
+                            let _ = event_tx.send(ClusterEvent::SingletonStopped {
+                                label: label.clone(),
+                                stopped_generation,
+                            });
+                        }
                         ControlMessage::Handshake(_) => {
                             tracing::warn!("Unexpected handshake from {node_id}");
                         }

--- a/murmer/src/lifecycle.rs
+++ b/murmer/src/lifecycle.rs
@@ -76,10 +76,10 @@ pub enum TerminationReason {
 pub struct ActorTerminated {
     pub label: String,
     pub reason: TerminationReason,
-    /// Optional tag set by [`ActorContext::watch_with_tag`] to identify the
-    /// *role* of the terminated actor without parsing the label string.
+    /// Optional tag set by [`ActorContext::watch_with_tag`](crate::actor::ActorContext::watch_with_tag)
+    /// to identify the *role* of the terminated actor without parsing the label string.
     ///
-    /// `None` when set via plain [`ActorContext::watch`].
+    /// `None` when set via plain [`ActorContext::watch`](crate::actor::ActorContext::watch).
     pub tag: Option<String>,
 }
 

--- a/murmer/src/system.rs
+++ b/murmer/src/system.rs
@@ -289,6 +289,30 @@ impl System {
         self.receptionist().lookup(label)
     }
 
+    /// Convenience: declare (or idempotently re-assert) a cluster singleton via
+    /// the local Coordinator and return the granted ownership.
+    ///
+    /// Requires a `Coordinator` started under the well-known `"coordinator"`
+    /// label (see [`crate::app::bridge::start_coordinator`]). For full control —
+    /// a custom coordinator label or an injected
+    /// [`GenerationSource`](crate::app::singleton::GenerationSource) — build the
+    /// `CoordinatorState` with `with_generation_source` and drive the
+    /// `Coordinator` endpoint directly.
+    #[cfg(feature = "app")]
+    pub async fn start_singleton(
+        &self,
+        spec: crate::app::singleton::SingletonSpec,
+    ) -> Result<crate::app::singleton::SingletonOwnership, String> {
+        use crate::app::coordinator::{Coordinator, StartSingleton};
+        let coordinator = self
+            .lookup::<Coordinator>("coordinator")
+            .ok_or_else(|| "no Coordinator registered under \"coordinator\"".to_string())?;
+        match coordinator.send_async(StartSingleton { spec }).await {
+            Ok(result) => result,
+            Err(e) => Err(format!("StartSingleton send failed: {e}")),
+        }
+    }
+
     /// Check an actor into a reception key group for discovery.
     ///
     /// # Examples


### PR DESCRIPTION
## Summary

Adds two first-class distribution primitives to the murmer orchestrator (the `app` feature), built for the appdata
single-writer-per-container deployment but generic to any clustered actor system:

1. **Hard placement constraints** — pin an actor to a specific node, or co-locate it with an "anchor" actor.
2. **Cluster singletons** — run *exactly one* instance of an actor cluster-wide, anchored to the leader / a node
   class / a specific node, with a **fenced** ownership handoff (a monotone `(term, seq)` generation) on failover and
   on graceful moves.

All changes are **additive and feature-gated** (`app`); a cluster that doesn't use these primitives behaves exactly
as before. Everything is verified under `--features app` (the `app` module is `#[cfg(feature = "app")]`-gated):
**89 lib unit tests**, **2 real-QUIC cluster-test scenarios**, clippy `-D warnings`, rustfmt, and `rustdoc
-D warnings` all clean; default-feature build unchanged (37 tests).

---

## How this changes cluster behavior

### Before
The Coordinator could place and redistribute **individual** actors using a `PlacementStrategy` (LeastLoaded /
Random / Pinned) and a per-actor `CrashStrategy` (Redistribute / WaitForReturn / Abandon). There was **no way to
say "pin this actor to that exact node," "keep this actor on the same node as that one," or "run exactly one of
these in the whole cluster."** On a node failure, actors were independently re-placed with no ownership/fencing
guarantee — two instances of a logically-singleton actor could briefly run at once (split-brain).

### After

**Placement is now controllable at the node level.** `PlacementConstraints` gains two hard filters:
- `required_node_id: Option<String>` — the actor is eligible on *exactly* that node; if it isn't alive, the spec
  gets `NoEligibleNodes` (it is **never** silently relocated — unlike the soft `Pinned` strategy).
- `colocate_with: Option<String>` — the actor is eligible only on a node **already running** the named anchor actor
  (positive affinity; the inverse of the existing `anti_affinity_labels`). Used to keep an actor group together on
  one node.

> ⚠️ **Internal API change:** `PlacementConstraints::is_satisfied_by(...)` now takes the candidate `node_id` as its
> first argument (needed to evaluate `required_node_id`). Custom callers of this method must update. The
> `PlacementStrategy` trait is unchanged.

**The cluster can now host singletons with a real exactly-one guarantee.** A new `ClusterSingleton` concept lets you
declare an actor that must run exactly once cluster-wide:

```rust
// app feature
let handle = system.start_singleton(
    "catalog", "myapp::Catalog", boot_bytes,
    SingletonAnchor::Leader,      // or Class(NodeClass::Worker) / Node("node-id")
    None,                         // drain_timeout: None = wait indefinitely on a graceful drain
).await?;
```

The Coordinator resolves the anchor to **one** owner node, spawns the single instance there, and tracks ownership.
Two new lifecycle behaviors follow:

- **Fenced failover.** When a singleton's owner node leaves or fails, the Coordinator automatically re-places the
  singleton on a surviving node **with a strictly-higher generation** — no manual intervention. (The owner-loss
  notification handlers `notify_node_failed` / `notify_node_left` are now `async`, and the cluster→Coordinator
  bridge forwards those events via `send_async`.)
- **Graceful drain handoff.** `MoveSingleton` (rebalance / anchor change) and Coordinator-level `StopSingleton`
  (teardown) mint a higher generation, ask the **live** old owner to stop (`StopSingleton` control message →
  the owner stops its instance and acks with `SingletonStoppedAck`), and only then place the successor. A
  `drain_timeout` force-proceeds if the old owner never acks.

### The fence — why two writers can't corrupt shared state

Every ownership grant carries a monotone, lexicographic `(term, seq)` generation (an FDB-style *recovery epoch*):
`term` bumps once per ownership change, `seq` per re-grant within a term. It packs into a single `u64`
(`(term << 32) | seq`) that a downstream system can compare with a plain integer compare. Because a successor
**always** bumps `term` during handoff, a stale/zombie ex-owner necessarily holds a **strictly-lower** generation.
A downstream single-writer guard (e.g. appdata's on-disk `HEAD.writer_gen` advance-or-reject) therefore fences the
old owner on its next write — **with no change to that comparison**. The generation is minted behind a pluggable
`GenerationSource` trait, so the authoritative store can be the default in-RAM source (single-node / tests) today
and a durable, consensus-backed source later, **without touching the downstream fence**.

---

## New public API (all under the `app` feature)

- `app::spec::PlacementConstraints` — `+ colocate_with`, `+ required_node_id`.
- `app::singleton` (new module) — `SingletonAnchor`, `SingletonGeneration { term, seq }` (+`packed()`),
  `SingletonSpec`, `SingletonOwnership` / `SingletonPhase`, `GenerationSource` trait + in-RAM
  `CoordinatorGenerationSource`, `resolve_owner(...)`.
- Coordinator messages — `StartSingleton`, `GetSingleton`, `MoveSingleton`, `StopSingleton`,
  `NotifySingletonStopped`, `SingletonDrainTimeout`. `CoordinatorState::with_generation_source(...)` injects a
  durable source.
- `System::start_singleton(...)` — convenience that looks up the well-known `"coordinator"` actor and submits.

## Wire / protocol changes (back-compatible within a single `PROTOCOL_VERSION`)

- `SpawnRequest` gains `singleton_generation: Option<u64>` (`#[serde(default)]`) — the packed generation, threaded
  to the spawning node for fenced singleton spawns; `None` for ordinary spawns.
- `ControlMessage::{StopSingleton, SingletonStoppedAck}` — the cross-node drain handshake.
- `ClusterEvent::SingletonStopped` — bridges the ack toward the Coordinator.

(The codec is bincode/positional; all cluster nodes run the same `PROTOCOL_VERSION`, and `SpawnRequest` is wire-only,
never persisted — so this is a same-version field, not a cross-version migration.)

## Dependencies

- `async-trait` added as an **optional** dependency, enabled only by the `app` feature (for the dyn-safe
  `GenerationSource` trait). No change to the default feature set.

---

## Backward compatibility

- A cluster that uses neither primitive is **behaviorally identical** to before (default placement + crash
  strategies unchanged; the new constraint fields default to "no constraint").
- New surface is gated behind `app` / opt-in messages.
- Only breaking change is the `is_satisfied_by` signature (internal helper).

## Testing

- **Unit (89, `--features app`):** placement constraints (pin / colocate / backward-compat); generation packing &
  ordering across the `u32` boundary; owner resolution; single-node placement + idempotent re-assert; **fenced
  failover** (owner dies → re-place with term 1→2; dead Node-pin clears owner); **graceful drain** (move drains then
  places with higher term; stale-generation ack ignored; teardown; no-op when the anchor is unchanged; drain-timeout
  force-proceed).
- **Cluster-tests (real QUIC, `murmer-cluster-tests`):** single-node start→spawn→Active; 3-node (Edge gateway hosts
  the Coordinator + two workers) graceful owner departure → fenced re-drive to the survivor with a strictly-higher
  term, exactly one instance.

## Known limitation / follow-up

The cross-node drain ack currently means **"stop signalled + observed," not "fully terminated."** Correctness does
not depend on it (the successor always carries a strictly-higher generation, so a briefly-lingering old instance is
fenced on its next write), but a downstream consumer that needs the old owner to *fully* release resources before
the successor starts (e.g. flushing/closing files) should rely on its own local drain barrier. Hardening the murmer
ack to a watch-based *await-terminated* handshake is a tracked follow-up.

## Commit map (8 commits, granular for review)

- `feat(placement)` — hard home-pin + positive-affinity `PlacementConstraints` (M1)
- `feat(singleton)` — generation types + `GenerationSource` (M4.1) → framing/control plane (M4.2) → Coordinator
  state + `StartSingleton`/`GetSingleton` (M4.3) → fenced **failover** re-drive (M4.4a) → `System::start_singleton`
  + real-QUIC cluster tests (M4.5) → graceful **drain** handoff (M4.4b)
- `docs(book)` — home-pin constraints + cluster singletons

🤖 Generated with [Claude Code](https://claude.com/claude-code)
