### PR TITLE
fix(supervisor): bound local-mailbox priority so remote dispatch cannot starve

### DIFF
--- a/murmer/src/app/coordinator.rs
+++ b/murmer/src/app/coordinator.rs
@@ -1449,9 +1449,7 @@ mod tests {
         async fn put_spec(&self, _label: &str, _spec: &SingletonSpec) -> Result<(), String> {
             Err("simulated backend write failure".into())
         }
-        async fn list(
-            &self,
-        ) -> Result<Vec<crate::app::singleton::SingletonRecord>, String> {
+        async fn list(&self) -> Result<Vec<crate::app::singleton::SingletonRecord>, String> {
             self.inner.list().await
         }
     }

--- a/murmer/src/supervisor.rs
+++ b/murmer/src/supervisor.rs
@@ -26,6 +26,12 @@ use crate::lifecycle::{RestartPolicy, SystemSignal, TerminationReason};
 use crate::receptionist::DeregisterGuard;
 use crate::wire::{DispatchRequest, EnvelopeProxy, RemoteResponse};
 
+/// Consecutive local mailbox messages processed before the dispatch channel
+/// gets one priority check. `select!`'s `biased` polling means a saturated
+/// mailbox would otherwise starve remote callers forever (issue #6); this
+/// bounds the wait for a remote dispatch to one local burst.
+pub(crate) const LOCAL_BURST_LIMIT: u64 = 64;
+
 /// Returns the mailbox and dispatch receivers so they can be reused on restart.
 /// The exit reason is communicated via the shared Arc<Mutex<TerminationReason>>.
 #[allow(clippy::too_many_arguments)]
@@ -48,13 +54,43 @@ where
 {
     let actor_type = std::any::type_name::<A>();
     let mut msg_count: u64 = 0;
+    let mut local_burst: u64 = 0;
 
     loop {
+        // Fairness slot: after a full burst of consecutive local messages,
+        // check the dispatch channel once before the mailbox. `try_recv` keeps
+        // the schedule a pure function of channel state — no randomness, no
+        // reliance on `select!`'s arm rotation — so simulation replay stays
+        // deterministic.
+        if local_burst >= LOCAL_BURST_LIMIT {
+            local_burst = 0;
+            if let Ok(request) = dispatch_rx.try_recv() {
+                if handle_dispatch(
+                    &mut actor,
+                    &mut state,
+                    &ctx,
+                    request,
+                    actor_type,
+                    &exit_reason,
+                )
+                .await
+                {
+                    break;
+                }
+                msg_count += 1;
+                if msg_count.is_multiple_of(64) {
+                    crate::runtime::yield_now().await;
+                }
+                continue;
+            }
+        }
+
         tokio::select! {
             // Deterministic branch priority: under a deterministic runtime,
             // `select!`'s default random branch order would break replay. The
             // ordering here (shutdown-ish signals after messages) is a
-            // deliberate, stable policy.
+            // deliberate, stable policy. Remote-dispatch starvation under a
+            // saturated mailbox is bounded by the fairness slot above.
             biased;
             msg = mailbox_rx.recv() => {
                 match msg {
@@ -74,6 +110,7 @@ where
                         #[cfg(feature = "monitor")]
                         instrument::message_processing_duration(actor_type, start.elapsed());
 
+                        local_burst += 1;
                         msg_count += 1;
                         if msg_count.is_multiple_of(64) {
                             crate::runtime::yield_now().await;
@@ -85,40 +122,18 @@ where
             req = dispatch_rx.recv() => {
                 match req {
                     Some(request) => {
-                        #[cfg(feature = "monitor")]
-                        let start = std::time::Instant::now(); // determinism-gate: allow — monitor instrumentation (measurement, not control flow)
-
-                        let fut = actor.dispatch_remote(
-                            &ctx,
+                        local_burst = 0;
+                        if handle_dispatch(
+                            &mut actor,
                             &mut state,
-                            &request.invocation.message_type,
-                            &request.invocation.payload,
-                        );
-                        let result = AssertUnwindSafe(fut).catch_unwind().await;
-                        match result {
-                            Ok(dispatch_result) => {
-                                instrument::message_processed(actor_type);
-                                #[cfg(feature = "monitor")]
-                                instrument::message_processing_duration(actor_type, start.elapsed());
-
-                                let response = RemoteResponse {
-                                    call_id: request.invocation.call_id,
-                                    result: dispatch_result.map_err(|e| e.to_string()),
-                                };
-                                let _ = request.respond_to.send(response);
-                            }
-                            Err(panic_info) => {
-                                instrument::message_failed(actor_type);
-                                let msg = extract_panic_message(&panic_info);
-                                // Send error response before breaking
-                                let response = RemoteResponse {
-                                    call_id: request.invocation.call_id,
-                                    result: Err(format!("actor panicked: {msg}")),
-                                };
-                                let _ = request.respond_to.send(response);
-                                *exit_reason.lock().unwrap() = TerminationReason::Panicked(msg);
-                                break;
-                            }
+                            &ctx,
+                            request,
+                            actor_type,
+                            &exit_reason,
+                        )
+                        .await
+                        {
+                            break;
                         }
                         msg_count += 1;
                         if msg_count.is_multiple_of(64) {
@@ -148,6 +163,57 @@ where
     (mailbox_rx, dispatch_rx)
 }
 
+/// Process one remote dispatch request and send the response. Returns `true`
+/// if the handler panicked and the supervisor should exit.
+async fn handle_dispatch<A>(
+    actor: &mut A,
+    state: &mut A::State,
+    ctx: &ActorContext<A>,
+    request: DispatchRequest,
+    actor_type: &'static str,
+    exit_reason: &Mutex<TerminationReason>,
+) -> bool
+where
+    A: Actor + RemoteDispatch + 'static,
+{
+    #[cfg(feature = "monitor")]
+    let start = std::time::Instant::now(); // determinism-gate: allow — monitor instrumentation (measurement, not control flow)
+
+    let fut = actor.dispatch_remote(
+        ctx,
+        state,
+        &request.invocation.message_type,
+        &request.invocation.payload,
+    );
+    let result = AssertUnwindSafe(fut).catch_unwind().await;
+    match result {
+        Ok(dispatch_result) => {
+            instrument::message_processed(actor_type);
+            #[cfg(feature = "monitor")]
+            instrument::message_processing_duration(actor_type, start.elapsed());
+
+            let response = RemoteResponse {
+                call_id: request.invocation.call_id,
+                result: dispatch_result.map_err(|e| e.to_string()),
+            };
+            let _ = request.respond_to.send(response);
+            false
+        }
+        Err(panic_info) => {
+            instrument::message_failed(actor_type);
+            let msg = extract_panic_message(&panic_info);
+            // Send error response before breaking
+            let response = RemoteResponse {
+                call_id: request.invocation.call_id,
+                result: Err(format!("actor panicked: {msg}")),
+            };
+            let _ = request.respond_to.send(response);
+            *exit_reason.lock().unwrap() = TerminationReason::Panicked(msg);
+            true
+        }
+    }
+}
+
 /// Extract a human-readable message from a panic payload.
 pub(crate) fn extract_panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
     if let Some(s) = payload.downcast_ref::<&str>() {
@@ -165,5 +231,150 @@ pub(crate) fn should_restart(policy: &RestartPolicy, reason: &TerminationReason)
         RestartPolicy::Temporary => false,
         RestartPolicy::Permanent => true,
         RestartPolicy::Transient => matches!(reason, TerminationReason::Panicked(_)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::actor::{DispatchError, Handler, Message};
+    use crate::receptionist::Receptionist;
+    use crate::wire::{RemoteInvocation, TypedEnvelope};
+
+    struct FloodActor;
+
+    struct FloodState {
+        local_processed: u64,
+    }
+
+    impl Actor for FloodActor {
+        type State = FloodState;
+    }
+
+    #[derive(Debug)]
+    struct Bump;
+
+    impl Message for Bump {
+        type Result = ();
+    }
+
+    impl Handler<Bump> for FloodActor {
+        fn handle(&mut self, _ctx: &ActorContext<Self>, state: &mut FloodState, _msg: Bump) {
+            state.local_processed += 1;
+        }
+    }
+
+    impl RemoteDispatch for FloodActor {
+        async fn dispatch_remote<'a>(
+            &'a mut self,
+            _ctx: &'a ActorContext<Self>,
+            state: &'a mut FloodState,
+            _message_type: &'a str,
+            _payload: &'a [u8],
+        ) -> Result<Vec<u8>, DispatchError> {
+            // Report how many local messages had been processed when this
+            // remote dispatch finally ran.
+            Ok(state.local_processed.to_le_bytes().to_vec())
+        }
+    }
+
+    /// Regression test for issue #6: `biased;` must not let a saturated local
+    /// mailbox starve remote dispatch. The mailbox is pre-filled with far more
+    /// messages than one local burst; the dispatch request must be served
+    /// within the first burst, not after the mailbox drains.
+    #[tokio::test]
+    async fn remote_dispatch_not_starved_by_saturated_mailbox() {
+        const FLOOD: u64 = 1000;
+
+        let receptionist = Receptionist::new();
+        let (mailbox_tx, mailbox_rx) =
+            mpsc::unbounded_channel::<Box<dyn EnvelopeProxy<FloodActor>>>();
+        let (dispatch_tx, dispatch_rx) = mpsc::unbounded_channel::<DispatchRequest>();
+        let (_shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+        let (system_tx, system_rx) = mpsc::unbounded_channel::<SystemSignal>();
+        let exit_reason = Arc::new(Mutex::new(TerminationReason::Stopped));
+
+        let guard = DeregisterGuard {
+            receptionist: receptionist.clone(),
+            label: "flood/test".to_string(),
+            reason: exit_reason.clone(),
+        };
+        let ctx = ActorContext {
+            label: "flood/test".to_string(),
+            node_id: "local".to_string(),
+            mailbox_tx: mailbox_tx.clone(),
+            receptionist: receptionist.clone(),
+            system_tx: system_tx.clone(),
+            reply_token: std::sync::Mutex::new(None),
+        };
+
+        // Saturate the mailbox before the supervisor runs, then queue one
+        // remote dispatch behind it. With `biased;` alone the dispatch would
+        // only run after all FLOOD local messages.
+        let mut reply_rxs = Vec::new();
+        for _ in 0..FLOOD {
+            let (tx, rx) = oneshot::channel();
+            mailbox_tx
+                .send(Box::new(TypedEnvelope {
+                    message: Bump,
+                    respond_to: tx,
+                }))
+                .unwrap();
+            reply_rxs.push(rx);
+        }
+        let (resp_tx, mut resp_rx) = oneshot::channel::<RemoteResponse>();
+        dispatch_tx
+            .send(DispatchRequest {
+                invocation: RemoteInvocation {
+                    call_id: 1,
+                    actor_label: "flood/test".to_string(),
+                    message_type: "test::Snapshot".to_string(),
+                    payload: Vec::new(),
+                },
+                respond_to: resp_tx,
+            })
+            .unwrap();
+        // Stop is only seen once the mailbox and dispatch arms are pending,
+        // so it cleanly ends the supervisor after everything drains.
+        system_tx.send(SystemSignal::Stop).unwrap();
+
+        let (_mb, _dp) = run_supervisor(
+            FloodActor,
+            FloodState { local_processed: 0 },
+            ctx,
+            mailbox_rx,
+            dispatch_rx,
+            shutdown_rx,
+            system_rx,
+            exit_reason,
+            guard,
+        )
+        .await;
+
+        let response = resp_rx
+            .try_recv()
+            .expect("remote dispatch should have been served");
+        let payload = response.result.expect("dispatch should succeed");
+        let processed_at_dispatch = u64::from_le_bytes(payload.try_into().unwrap());
+
+        assert!(
+            processed_at_dispatch < FLOOD,
+            "remote dispatch was starved: ran only after all {FLOOD} local messages"
+        );
+        assert!(
+            processed_at_dispatch <= LOCAL_BURST_LIMIT,
+            "remote dispatch should run within one local burst \
+             (ran after {processed_at_dispatch} local messages, limit {LOCAL_BURST_LIMIT})"
+        );
+
+        // All local messages must still have been processed.
+        let mut delivered = 0;
+        for rx in reply_rxs {
+            if rx.await.is_ok() {
+                delivered += 1;
+            }
+        }
+        assert_eq!(delivered, FLOOD, "every local message should be handled");
     }
 }


### PR DESCRIPTION
Closes #6.

## Problem

The supervisor's `tokio::select!` uses `biased;` (added for deterministic arm ordering under simulation replay), which gives the local mailbox branch unconditional priority over the remote-dispatch branch. `mailbox_rx` and `dispatch_rx` are independent mpsc receivers, so under a saturated local mailbox the dispatch arm is never polled and remote callers time out against a healthy node. The existing `yield_now` every 64 messages reschedules the task but does not rotate arms.

## Fix

`run_supervisor` now counts consecutive locally-drained mailbox messages. After `LOCAL_BURST_LIMIT` (64) consecutive local messages, it gives `dispatch_rx` exactly one non-blocking `try_recv` check before re-entering the unchanged `biased;` select, resetting the counter whenever a remote dispatch is served. A pending remote request is therefore served within at most one 64-message local burst instead of starving indefinitely.

Determinism is preserved: the polling order is a pure function of channel state and the counter — no unseeded randomness and no reliance on `select!`'s random arm rotation — so simulation replay (`feature = "sim"`) sees the same schedule for the same input. `scripts/check-determinism.sh` still passes. The `yield_now` cadence is kept unchanged (it addresses task-level fairness across actors, a separate concern). Dispatch-request handling is factored into a shared `handle_dispatch` helper so the fairness slot and the select arm run identical code.

## Testing

- New regression test `supervisor::tests::remote_dispatch_not_starved_by_saturated_mailbox`: pre-fills the mailbox with 1000 messages, queues a `DispatchRequest` behind them, and asserts the `RemoteResponse` is produced within one local burst (≤64 local messages) rather than after the mailbox drains. Verified it fails when the fairness slot is neutered.
- Full workspace suite: 232 tests green.
- `cargo test -p murmer --features sim`: 97 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMKtzYGESwyajKjAx9YFpu

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMKtzYGESwyajKjAx9YFpu)_