### PR TITLE
feat(sim): TerminateHook — a seam for slow-to-die actors

### DIFF
--- a/book/src/simulation-extending.md
+++ b/book/src/simulation-extending.md
@@ -27,7 +27,7 @@ not know about and the oracles that check your application's invariants.
 
 ## The seam primitives you build on
 
-Three primitives carry the whole Layer-3 pattern.
+Four primitives carry the whole Layer-3 pattern.
 
 **One seed, one root.** `world.derive_seed("vfs")` gives you an independent `u64`
 seeded off the world's root seed. You feed it into whatever PRNG your fault stream
@@ -74,6 +74,49 @@ through the runtime, not through `tokio::time` or `Instant::now`. The runtime's
 `sleep` and `now` are virtual under sim, so a fault that fires after a delay (a slow
 disk, a write that lands late) advances when the test advances the clock. If you
 reach for the real clock, your fault stops being deterministic and you have a hole.
+
+**The terminate hook.** Actor deregistration is normally instant. The supervisor
+loop breaks and the `DeregisterGuard` fires in `Drop`, which is synchronous, so
+there is no moment where an actor is stopped but still in the registry. Real
+systems are messier. An actor can accept its stop and then take time to drain a
+mailbox or tear down external resources, staying registered but not serving for a
+while. Callers have to tolerate that window, and you cannot test the tolerance if
+the window is zero-width.
+
+`Receptionist::set_terminate_hook` opens it. The hook is awaited between the
+supervisor exiting and the guard firing, so while it is pending the actor still
+shows up in `lookup`, still appears in listings, and its watches have not fired:
+
+```rust,ignore
+struct SlowToDie {
+    label: &'static str,
+    delay: Duration,
+    runtime: Arc<dyn Runtime>,
+}
+
+impl TerminateHook for SlowToDie {
+    fn before_deregister(&self, label: &str, _r: &TerminationReason) -> BoxFuture<'static, ()> {
+        if label == self.label {
+            self.runtime.sleep(self.delay)   // virtual time, like every other fault
+        } else {
+            Box::pin(std::future::ready(()))
+        }
+    }
+}
+
+world.system().receptionist().set_terminate_hook(Some(Arc::new(SlowToDie {
+    label: "cache/user",
+    delay: Duration::from_secs(5),
+    runtime: Arc::new(world.runtime().clone()),
+})));
+```
+
+Two things to know. The hook fires for every actor terminating on that node,
+including murmer's internal ones, so filter on the label you are handed. And it
+is a fault seam, not a place to do work: it runs on the supervisor's task and it
+holds the registry entry for as long as it stays pending, so a hook that never
+completes leaks the entry. It does not fire on the restart-limit-exceeded path,
+where the receptionist deregisters directly instead of through a supervisor exit.
 
 ## The shape of a Layer-3 add-on
 

--- a/murmer/src/lib.rs
+++ b/murmer/src/lib.rs
@@ -288,7 +288,8 @@ pub use client::{ClientOptions, MurmerClient};
 pub use cluster::net::sim_cluster::{DrainedEvents, SimCluster, SimClusterBuilder};
 pub use endpoint::Endpoint;
 pub use lifecycle::{
-    ActorFactory, ActorTerminated, BackoffConfig, RestartConfig, RestartPolicy, TerminationReason,
+    ActorFactory, ActorTerminated, BackoffConfig, RestartConfig, RestartPolicy, TerminateHook,
+    TerminationReason,
 };
 pub use listing::{Listing, ListingEvent, ReceptionKey, WatchedListing};
 pub use node::run_node_receiver;

--- a/murmer/src/lifecycle.rs
+++ b/murmer/src/lifecycle.rs
@@ -214,6 +214,92 @@ pub trait ActorFactory: Send + 'static {
     fn create(&mut self) -> (Self::Actor, <Self::Actor as Actor>::State);
 }
 
+// =============================================================================
+// TERMINATE HOOK (fault-injection seam)
+// =============================================================================
+
+/// Fault-injection seam fired between an actor's supervisor loop exiting and
+/// the actor's removal from the receptionist.
+///
+/// # Why this exists
+///
+/// Deregistration is normally instantaneous: the supervisor loop breaks and the
+/// `DeregisterGuard` fires in `Drop`, which is synchronous. Real systems are not
+/// so tidy — an actor can accept its stop, then take time to drain a mailbox or
+/// tear down external resources, staying *registered but not serving* for a
+/// while. Callers must tolerate that window (murmer's own eviction paths wait on
+/// deregistration with a deadline), but without a seam there is no way to *test*
+/// that tolerance, because the window is zero-width by construction.
+///
+/// Install a hook and the returned future is awaited inside that window. While
+/// it is pending the actor is still in the receptionist — `lookup` finds it,
+/// listings include it, watches have not fired — and its supervisor is no longer
+/// processing messages. That is precisely the "slow to die" state.
+///
+/// # Determinism
+///
+/// The hook returns a future, so a simulation test builds its delay from the
+/// [`Runtime`](crate::runtime::Runtime) seam (`runtime.sleep(d)`) and the wait
+/// runs on virtual time — reproducible from the world seed like everything else.
+/// Do not sleep on wall-clock time inside a hook used under simulation.
+///
+/// # Scope
+///
+/// This is a test/fault-injection seam. It is not a place to do real work:
+/// it runs on the supervisor's task, it blocks the actor's deregistration for as
+/// long as it is pending, and a hook that never completes leaks a registry entry.
+/// It fires on every terminating actor on the node, including murmer's internal
+/// ones, so a hook that only wants one actor must filter on `label`.
+///
+/// It does *not* fire on the restart-limit-exceeded path
+/// (`TerminationReason::RestartLimitExceeded`), where the receptionist
+/// deregisters directly rather than through a supervisor exit.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use murmer::lifecycle::{TerminateHook, TerminationReason};
+/// use murmer::runtime::{BoxFuture, Runtime};
+/// use std::sync::Arc;
+/// use std::time::Duration;
+///
+/// /// Makes one labelled actor take `delay` of virtual time to de-register.
+/// struct SlowToDie {
+///     label: String,
+///     delay: Duration,
+///     runtime: Arc<dyn Runtime>,
+/// }
+///
+/// impl TerminateHook for SlowToDie {
+///     fn before_deregister(
+///         &self,
+///         label: &str,
+///         _reason: &TerminationReason,
+///     ) -> BoxFuture<'static, ()> {
+///         if label == self.label {
+///             self.runtime.sleep(self.delay)
+///         } else {
+///             Box::pin(std::future::ready(()))
+///         }
+///     }
+/// }
+///
+/// world.system().receptionist().set_terminate_hook(Some(Arc::new(SlowToDie {
+///     label: "cache/user".into(),
+///     delay: Duration::from_secs(5),
+///     runtime: Arc::new(world.runtime().clone()),
+/// })));
+/// ```
+pub trait TerminateHook: Send + Sync + 'static {
+    /// Called with the terminating actor's label and exit reason. The actor is
+    /// still registered until the returned future completes.
+    fn before_deregister(
+        &self,
+        label: &str,
+        reason: &TerminationReason,
+    ) -> crate::runtime::BoxFuture<'static, ()>;
+}
+
 /// Internal: signals delivered to actors from the system.
 pub(crate) enum SystemSignal {
     ActorTerminated(ActorTerminated),

--- a/murmer/src/receptionist.rs
+++ b/murmer/src/receptionist.rs
@@ -32,8 +32,8 @@ use crate::actor::{Actor, ActorContext, RemoteDispatch};
 use crate::endpoint::Endpoint;
 use crate::instrument;
 use crate::lifecycle::{
-    ActorFactory, ActorTerminated, RestartConfig, RestartPolicy, SystemSignal, TerminationReason,
-    WatchEntry,
+    ActorFactory, ActorTerminated, RestartConfig, RestartPolicy, SystemSignal, TerminateHook,
+    TerminationReason, WatchEntry,
 };
 use crate::listing::{
     ErasedListingSender, ErasedReceptionKey, ErasedWatchedListingSender, Listing, ReceptionKey,
@@ -269,6 +269,12 @@ struct ReceptionistInner {
     /// The runtime seam: all supervisor/background spawns and timers go through
     /// this, so a deterministic `SimRuntime` can drive the whole node.
     runtime: Arc<dyn Runtime>,
+    /// Fault-injection seam: awaited between a supervisor's loop exiting and its
+    /// `DeregisterGuard` firing. `None` in production (one uncontended lock per
+    /// actor exit). Behind a `Mutex` rather than in `ReceptionistConfig` so a
+    /// test can install it on an already-built system, and swap it between
+    /// scenario phases.
+    terminate_hook: Mutex<Option<Arc<dyn TerminateHook>>>,
 }
 
 // =============================================================================
@@ -340,6 +346,7 @@ impl Receptionist {
                 pending_notifications: Mutex::new(Vec::new()),
                 blip_pending: Mutex::new(HashMap::new()),
                 runtime,
+                terminate_hook: Mutex::new(None),
             }),
         };
 
@@ -362,6 +369,25 @@ impl Receptionist {
     /// The runtime seam this receptionist (and its actors) run on.
     pub fn runtime(&self) -> &Arc<dyn Runtime> {
         &self.inner.runtime
+    }
+
+    /// Install (or clear, with `None`) the [`TerminateHook`] for actors on this
+    /// receptionist — the fault-injection seam that widens the window between a
+    /// supervisor exiting and the actor leaving the registry.
+    ///
+    /// Takes effect for every actor that terminates after this call; an actor
+    /// already waiting inside a previously-installed hook is unaffected.
+    ///
+    /// See [`TerminateHook`] for the contract — in particular that it fires for
+    /// *all* actors on the node, so a hook targeting one actor must filter on
+    /// the label it is passed.
+    pub fn set_terminate_hook(&self, hook: Option<Arc<dyn TerminateHook>>) {
+        *self.inner.terminate_hook.lock().unwrap() = hook;
+    }
+
+    /// The currently installed [`TerminateHook`], if any.
+    pub(crate) fn terminate_hook(&self) -> Option<Arc<dyn TerminateHook>> {
+        self.inner.terminate_hook.lock().unwrap().clone()
     }
 
     pub fn node_id(&self) -> &str {

--- a/murmer/src/sim.rs
+++ b/murmer/src/sim.rs
@@ -836,6 +836,135 @@ mod tests {
         assert!(result.is_err(), "block_on should panic on a sim deadlock");
     }
 
+    /// A [`TerminateHook`] that makes one labelled actor slow to de-register,
+    /// on virtual time. Records the labels and reasons it saw.
+    struct SlowToDie {
+        label: &'static str,
+        delay: Duration,
+        runtime: SimRuntime,
+        seen: Arc<Mutex<Vec<(String, String)>>>,
+    }
+
+    impl crate::lifecycle::TerminateHook for SlowToDie {
+        fn before_deregister(
+            &self,
+            label: &str,
+            reason: &TerminationReason,
+        ) -> BoxFuture<'static, ()> {
+            self.seen
+                .lock()
+                .unwrap()
+                .push((label.to_string(), format!("{reason:?}")));
+            if label == self.label {
+                self.runtime.sleep(self.delay)
+            } else {
+                Box::pin(std::future::ready(()))
+            }
+        }
+    }
+
+    /// The fault-injection seam datastorekit needs: an actor that has accepted
+    /// its stop but is slow to die stays *registered but not serving* for the
+    /// hook's duration. Without the hook that window is zero-width, because
+    /// deregistration rides on `DeregisterGuard`'s synchronous `Drop`.
+    #[test]
+    fn terminate_hook_holds_a_dying_actor_registered() {
+        let mut world = SimWorld::new(7);
+        let seen = Arc::new(Mutex::new(Vec::new()));
+
+        world
+            .system()
+            .receptionist()
+            .set_terminate_hook(Some(Arc::new(SlowToDie {
+                label: "counter/dying",
+                delay: Duration::from_secs(5),
+                runtime: world.runtime().clone(),
+                seen: seen.clone(),
+            })));
+
+        let ep = world
+            .system()
+            .start("counter/dying", Counter, CounterState::default());
+        assert_eq!(world.send(&ep, Increment { amount: 1 }).unwrap(), 1);
+
+        world.system().stop("counter/dying");
+        world.pump();
+
+        // The supervisor has exited (stop accepted) and the hook has fired, but
+        // the guard has not: the actor is still discoverable.
+        assert_eq!(
+            &*seen.lock().unwrap(),
+            &[("counter/dying".to_string(), "Stopped".to_string())],
+            "hook should fire exactly once, with the clean-stop reason"
+        );
+        assert!(
+            world.system().lookup::<Counter>("counter/dying").is_some(),
+            "actor must stay registered while the terminate hook is pending"
+        );
+
+        // One second short of the hook's delay — still there.
+        world.advance(Duration::from_secs(4));
+        assert!(
+            world.system().lookup::<Counter>("counter/dying").is_some(),
+            "actor must stay registered until the hook's virtual delay elapses"
+        );
+
+        // Past it: the hook completes, the guard drops, the entry goes.
+        world.advance(Duration::from_secs(2));
+        assert!(
+            world.system().lookup::<Counter>("counter/dying").is_none(),
+            "actor must de-register once the terminate hook completes"
+        );
+    }
+
+    /// The delay is virtual-clock driven, so the window a fault test opens is a
+    /// pure function of the seed — the same property every other sim fault has.
+    #[test]
+    fn terminate_hook_deregistration_time_is_deterministic() {
+        fn dies_at(seed: u64) -> Duration {
+            let mut world = SimWorld::new(seed);
+            world
+                .system()
+                .receptionist()
+                .set_terminate_hook(Some(Arc::new(SlowToDie {
+                    label: "counter/dying",
+                    delay: Duration::from_secs(5),
+                    runtime: world.runtime().clone(),
+                    seen: Arc::new(Mutex::new(Vec::new())),
+                })));
+            let _ep = world
+                .system()
+                .start("counter/dying", Counter, CounterState::default());
+            world.system().stop("counter/dying");
+            world.pump();
+
+            // Step one virtual second at a time until the entry disappears.
+            for _ in 0..60 {
+                if world.system().lookup::<Counter>("counter/dying").is_none() {
+                    break;
+                }
+                world.advance(Duration::from_secs(1));
+            }
+            world.now()
+        }
+
+        assert_eq!(dies_at(1), Duration::from_secs(5));
+        assert_eq!(dies_at(1), dies_at(99), "seed must not change the window");
+    }
+
+    /// No hook installed (the production default) means no behavior change:
+    /// stopping an actor de-registers it without any clock advance.
+    #[test]
+    fn without_a_terminate_hook_deregistration_is_immediate() {
+        let mut world = SimWorld::new(7);
+        let _ep = world
+            .system()
+            .start("counter/dying", Counter, CounterState::default());
+        world.system().stop("counter/dying");
+        world.pump();
+        assert!(world.system().lookup::<Counter>("counter/dying").is_none());
+    }
+
     #[test]
     fn replay_is_stable_across_runs() {
         // Replay covers what SimWorld controls: task scheduling, virtual-time

--- a/murmer/src/supervisor.rs
+++ b/murmer/src/supervisor.rs
@@ -13,6 +13,11 @@
 //!
 //! On exit, the `DeregisterGuard` RAII type automatically removes the actor
 //! from the receptionist and fires any registered watches.
+//!
+//! Between those two events sits the [`TerminateHook`](crate::lifecycle::TerminateHook)
+//! seam: a fault-injection point that holds the actor in the "stopped but still
+//! registered" state a test otherwise can't reach, because deregistration rides
+//! on a synchronous `Drop`. `None` in production.
 
 use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, Mutex};
@@ -159,6 +164,17 @@ where
             }
         }
     }
+    // Fault-injection seam. The loop has exited — this actor no longer serves
+    // messages — but its `DeregisterGuard` has not fired, so it is still in the
+    // receptionist: `lookup` finds it, listings include it, watches are silent.
+    // Awaiting here holds the actor in that "accepted its stop, not yet gone"
+    // state, which is zero-width otherwise (deregistration rides on a
+    // synchronous `Drop`) and therefore untestable. `None` in production.
+    if let Some(hook) = ctx.receptionist.terminate_hook() {
+        let reason = exit_reason.lock().unwrap().clone();
+        hook.before_deregister(&ctx.label, &reason).await;
+    }
+
     // _deregister_guard is dropped here → calls receptionist.deregister_with_reason(label, reason)
     (mailbox_rx, dispatch_rx)
 }
@@ -376,5 +392,50 @@ mod tests {
             }
         }
         assert_eq!(delivered, FLOOD, "every local message should be handled");
+    }
+
+    /// The terminate hook is a real seam on the production (Tokio) path too, not
+    /// just under simulation — the sim tests in `sim.rs` cover the virtual-clock
+    /// behavior; this one covers that the branch is live on `TokioRuntime`.
+    #[tokio::test]
+    async fn terminate_hook_delays_deregistration_on_the_tokio_path() {
+        use crate::lifecycle::TerminateHook;
+        use crate::runtime::{BoxFuture, Runtime, TokioRuntime};
+        use std::time::Duration;
+
+        struct SlowToDie;
+
+        impl TerminateHook for SlowToDie {
+            fn before_deregister(
+                &self,
+                label: &str,
+                _reason: &TerminationReason,
+            ) -> BoxFuture<'static, ()> {
+                assert_eq!(label, "flood/dying");
+                // Through the seam, like a real hook would: the same impl works
+                // unchanged when handed a `SimRuntime` instead.
+                TokioRuntime.sleep(Duration::from_millis(200))
+            }
+        }
+
+        let receptionist = Receptionist::new();
+        receptionist.set_terminate_hook(Some(Arc::new(SlowToDie)));
+
+        let _ep = receptionist.start("flood/dying", FloodActor, FloodState { local_processed: 0 });
+        receptionist.stop("flood/dying");
+
+        // Well inside the hook's delay: stop accepted, actor still registered.
+        TokioRuntime.sleep(Duration::from_millis(50)).await;
+        assert!(
+            receptionist.lookup::<FloodActor>("flood/dying").is_some(),
+            "actor must stay registered while the terminate hook is pending"
+        );
+
+        // Past it: the hook completes, the guard drops, the entry goes.
+        TokioRuntime.sleep(Duration::from_millis(300)).await;
+        assert!(
+            receptionist.lookup::<FloodActor>("flood/dying").is_none(),
+            "actor must de-register once the terminate hook completes"
+        );
     }
 }


### PR DESCRIPTION
## Why

Deregistration rides on `DeregisterGuard::drop`, which is synchronous. That makes the window where an actor has accepted its stop but is still in the receptionist **zero-width**. Production tolerates a real window (the eviction wait loops and their deadlines exist precisely for it), but tests could never open one, because there was no await point between the supervisor loop breaking and the guard firing.

This came in as a request from the datastorekit team: twice now they've needed to simulate an actor that's slow to die (mailbox draining, slow teardown), and last time the fault-injection site had to be deleted rather than fixed, because the delay would have to go inside murmer's runtime.

This is also the "first real fault call-site" that the June simulation handoff doc said `BuggifyStream` was waiting on.

## What

```rust
pub trait TerminateHook: Send + Sync + 'static {
    fn before_deregister(&self, label: &str, reason: &TerminationReason)
        -> BoxFuture<'static, ()>;
}

receptionist.set_terminate_hook(Some(Arc::new(my_hook)));  // None clears
```

The returned future is awaited in `run_supervisor` between the loop breaking and the guard dropping. While it is pending the actor is registered but not serving: `lookup` finds it, listings include it, watches are silent.

Two design notes:

- **Behind a `Mutex` on `ReceptionistInner`, not in `ReceptionistConfig`.** Config is frozen at construction and `SimWorld::new(seed)` builds the `System` internally, so a config-based hook could never be installed by a test using the standard harness. The mutex also allows swapping hooks between scenario phases.
- **Returns a future rather than taking a `Duration`.** This forces the delay through the `Runtime` seam, so `runtime.sleep(d)` is virtual under sim and the fault window is a function of the seed like every other fault. A `Duration` parameter would have invited an internal `tokio::time::sleep` and put a wall-clock dependency on the sim path.

`None` by default: one uncontended lock per actor exit, no behavior change in production.

## Limits (documented on the trait)

- Fires for **every** actor terminating on the node, including murmer's internal ones. A hook targeting one actor must filter on the label it is handed.
- Does **not** fire on the restart-limit-exceeded path, where the receptionist deregisters directly rather than through a supervisor exit.
- It is a fault seam, not a place to do work: it runs on the supervisor's task and holds the registry entry for as long as it stays pending.

## Tests

Three sim tests (`registered-while-pending`, `deterministic window`, `no-hook-is-immediate`) and one Tokio-path test, so production behavior is not assumed from sim. The Tokio test sleeps through `TokioRuntime.sleep` rather than `tokio::time::sleep` — it reads better and keeps the determinism gate clean without a suppression marker.

## Verification

- `cargo nextest run -p murmer --features sim,app` — 165 passed
- `cargo nextest run -p murmer` — 58 passed
- `bash scripts/check-determinism.sh` — clean across 15 core modules
- `cargo clippy -p murmer --features sim,app --all-targets` — clean

Docs: added as the fourth seam primitive in `book/src/simulation-extending.md`, plus a pointer in the `supervisor.rs` module header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)