### PR TITLE
fix(sim): bias the last three sim-reachable select! sites

### DIFF
--- a/murmer/src/cluster/membership.rs
+++ b/murmer/src/cluster/membership.rs
@@ -137,6 +137,20 @@ pub(crate) fn spawn_timer_manager(
             let next_deadline = heap.peek().map(|Reverse(s)| s.deadline);
 
             tokio::select! {
+                // Deterministic branch priority. Under a virtual clock,
+                // "a command arrives at the same instant a deadline is due" is
+                // common rather than rare, and an unbiased `select!` resolved it
+                // with Tokio's RNG — outside the sim seed's control, so a SWIM
+                // round could shift between runs of the same seed.
+                //
+                // Commands win. A `CancelAll` racing a due timer should cancel
+                // it, and an `Insert` with an earlier deadline than the current
+                // head should be visible before anything fires. Draining a burst
+                // of N commands costs N iterations, but `now` does not advance
+                // across them, so due timers still fire at the correct virtual
+                // time — the drain below is `deadline <= now`, not "one per
+                // wakeup". Nothing is lost or deferred in virtual time.
+                biased;
                 cmd = cmd_rx.recv() => {
                     match cmd {
                         Some(TimerCommand::Insert { timer, timer_id, delay }) => {

--- a/murmer/src/cluster/net/mod.rs
+++ b/murmer/src/cluster/net/mod.rs
@@ -198,6 +198,19 @@ pub async fn run_control_stream_writer(
 ) {
     loop {
         tokio::select! {
+            // Deterministic branch priority: an unbiased `select!` here picks
+            // between "write the queued frame" and "we were cancelled" using
+            // Tokio's own RNG, which the sim seed does not control — so a
+            // shutdown racing a queued write was silently nondeterministic.
+            //
+            // Shutdown wins deliberately. `SimCluster::crash` models an abrupt
+            // crash by cancelling this token, and a crashed node that first
+            // flushed its pending control frames would be an unrealistically
+            // graceful corpse. Cancellation drops the queue, as a real crash
+            // does. In the happy path `cancelled()` is pending, so the write
+            // arm runs exactly as before.
+            biased;
+            _ = shutdown.cancelled() => break,
             msg = rx.recv() => {
                 let Some(msg) = msg else { break };
                 let frame = match framing::encode_message(&msg) {
@@ -212,7 +225,6 @@ pub async fn run_control_stream_writer(
                     break;
                 }
             }
-            _ = shutdown.cancelled() => break,
         }
     }
     let _ = send.finish();
@@ -280,10 +292,15 @@ pub async fn run_control_stream_reader(
         },
     );
     tokio::select! {
+        // Deterministic branch priority, same reasoning as the writer above:
+        // a cancelled node stops reading inbound frames rather than finishing
+        // the pump, so a crash looks like a crash. `cancelled()` is pending in
+        // the happy path, so the pump runs unchanged.
+        biased;
+        _ = shutdown.cancelled() => {}
         result = pump => match result {
             Ok(()) => tracing::debug!("Control stream from {node_id} closed"),
             Err(e) => tracing::warn!("Control stream read error from {node_id}: {e}"),
         },
-        _ = shutdown.cancelled() => {}
     }
 }


### PR DESCRIPTION
## Why

The M1 integrity pass (`e43cf89`) added `biased;` to the decision-path `select!`s, but three sim-reachable sites were left unbiased. An unbiased `tokio::select!` resolves ties using Tokio's own RNG, which the sim seed does not control — so the same seed could take a different branch on a different run.

These were found while answering a determinism question from the datastorekit team, by auditing every `select!` in the crate rather than trusting the June handoff doc's caveat list, which had gone stale.

## The three sites and the priority chosen

**`cluster/membership.rs` — the foca timer manager.** A `TimerCommand` arriving at the same virtual instant a deadline is due. Under a virtual clock that coincidence is common rather than rare, so this is the one of the three that can actually shift a SWIM round.

Commands win. A `CancelAll` racing a due timer should cancel it, and an `Insert` with an earlier deadline than the current head should be visible before anything fires. Draining a burst of N commands costs N iterations, but `now` does not advance across them and the drain is `deadline <= now` rather than one-per-wakeup, so nothing is deferred in virtual time.

**`cluster/net/mod.rs` — the control-stream writer and reader, each racing shutdown.** Shutdown wins.

This is deliberate, not arbitrary. `SimCluster::crash` models an abrupt crash by cancelling this token, and a crashed node that first flushed its pending control frames would be an unrealistically graceful corpse. Cancellation drops the queue, as a real crash does.

Graceful departure is unaffected, and checking that is what makes shutdown-wins safe: `ClusterSystem::shutdown` broadcasts `Departure` and then sleeps 50ms *before* cancelling, so that path rides an explicit grace period rather than a race with the writer.

In all three cases the newly-prioritised arm is pending on the happy path, so the hot path is unchanged.

## On testing — read this before approving

**No test in this PR reproduces the original race.** Forcing a command and a deadline onto the same virtual instant on demand is not something the harness can express today. More to the point, the 256-seed sweeps did not catch the hole in the first place — they assert converged sets, which a one-round timer shift does not perturb — so they cannot prove the fix either. They are here as regression evidence that the change breaks nothing, not as proof that it fixes something.

The correctness argument is the arm ordering, documented inline at each site.

This class of bug is currently review-only: `scripts/check-determinism.sh` is token-based and says so explicitly. **Suggested follow-up:** extend the gate to flag unbiased `tokio::select!` in a list of sim-reachable cluster modules, so this is an enforced invariant rather than a cleanup that happened once. I did not do it here because picking which `cluster/*` modules count as sim-reachable is a judgment call worth agreeing on separately, and a gate that false-positives on the genuinely prod-only sites (`client.rs`, `discovery.rs`, `transport.rs`, `allowlist.rs`) would be worse than no gate.

## Verification

- `cargo nextest run -p murmer --features sim,app` — 161 passed
- `cargo nextest run -p murmer` — 57 passed, including `test_graceful_departure`
- `MURMER_SIM_SWEEP_SEEDS=256 ... seed_sweep` — both invariants passed at CI breadth
- `cargo nextest run -p murmer-cluster-tests` — 10/10 passed. One leaky on the known intermittent iroh teardown; since this PR touches teardown I did not wave it through, and re-ran that test three times in isolation, all clean.
- Determinism gate and `sim,app` clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)