### PR TITLE
chore(deps): stop dependabot proposing rand 0.10 until foca moves

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,23 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      # rand 0.10 is a breaking release and we cannot take it yet: foca types
+      # our SWIM state as `Foca<_, _, StdRng, _>`, so foca and murmer must agree
+      # on which `rand` that `StdRng` comes from. foca depends on `rand ^0.9`
+      # — including foca 1.0.0, checked 2026-07-27 — so bumping murmer alone
+      # puts two `rand` versions in the tree and every `apply_many`/
+      # `handle_timer`/`handle_data` call fails its trait bounds. rand_chacha
+      # 0.10 is the same story: it pairs with rand 0.10, and `SimRuntime`'s
+      # seeded ChaCha8Rng is the root of the whole determinism story.
+      #
+      # This suppressed PRs #21, #26 and #29, which were red for exactly this
+      # reason and could not be fixed on our side.
+      #
+      # REMOVE both entries once foca publishes a release built on rand 0.10;
+      # the two crates then move together in one PR. 0.9.x patches still come
+      # through, so security fixes are not suppressed.
+      - dependency-name: "rand"
+        versions: [">= 0.10"]
+      - dependency-name: "rand_chacha"
+        versions: [">= 0.10"]


### PR DESCRIPTION
## Why

Three dependabot PRs were red for one shared reason, and none of them could be fixed on our side:

- #29 — rand 0.9.5 → 0.10.2
- #26 — rand_chacha 0.9.0 → 0.10.0
- #21 — rand 0.9.2 → 0.10.1 (superseded by #29)

rand 0.10 is a breaking release. foca types our SWIM state as `Foca<_, _, StdRng, _>`, so foca and murmer have to agree on which `rand` that `StdRng` comes from. foca depends on `rand ^0.9`, and I checked crates.io directly — **foca 1.0.0 still requires `rand ^0.9`**, so upgrading foca does not unblock this either.

Bumping murmer alone puts two `rand` versions in the tree, which is what the CI logs show:

```
error[E0599]: the method `apply_many` exists for struct
  `Foca<NodeIdentity, BincodeCodec<Configuration>, StdRng, NoCustomBroadcast>`,
  but its trait bounds were not satisfied
error[E0277]: the trait bound `StdRng: rand::rng::Rng` is not satisfied
error[E0599]: no associated function named `seed_from_u64` found for struct `ChaCha8Rng`
```

rand_chacha 0.10 is the same story: it pairs with rand 0.10, and `SimRuntime`'s seeded `ChaCha8Rng` is the root of the entire determinism story, so it cannot move independently.

## What

Ignore `>= 0.10` for both crates. Without this the three PRs get recreated weekly and the PR list stays permanently red for a reason nobody can act on.

Scoped deliberately: 0.9.x patches still come through, so security fixes are **not** suppressed. Only the 0.10 line is held.

Both entries come out together once foca ships a release built on rand 0.10 — at which point the two crates move in a single coordinated PR, which is how they should have moved anyway.

## Note

This is a repo policy change rather than a code change, so it is easy to veto. If you would rather keep the PRs open as a visible reminder, close this and I will reopen them with an explanatory comment instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)