### PR TITLE
docs(book): document the terminate hook where readers will look for it

### DIFF
--- a/book/src/simulation.md
+++ b/book/src/simulation.md
@@ -98,6 +98,14 @@ complete (every task is parked, no timer is pending). That almost always means
 the future is awaiting a reply or message that no actor will ever send, which is
 a real bug worth seeing.
 
+Actor teardown has a fault seam of its own. `Receptionist::set_terminate_hook`
+holds an actor in the "accepted its stop, not yet deregistered" state for as long
+as you like on the virtual clock. That state is zero-width in normal operation,
+because deregistration rides on a synchronous `Drop`, so without the hook there
+is no way to test the code that waits on it. See
+[Supervision](./supervision.md) for the contract and
+[Extending Simulation](./simulation-extending.md) for a worked example.
+
 ## Running a whole actor stack
 
 The first test showed one actor. The thing you will actually do most is stand up

--- a/book/src/supervision.md
+++ b/book/src/supervision.md
@@ -106,6 +106,42 @@ When a supervised actor restarts:
 
 This means endpoints held by other actors remain valid through restarts — messages sent during the brief restart window are queued in the supervisor's mailbox and delivered to the new instance.
 
+### Deregistration on termination
+
+When a supervisor exits, whatever the reason, a `DeregisterGuard` removes the
+actor from the receptionist and fires any watches. That guard runs in `Drop`, so
+in normal operation deregistration is instantaneous. There is no moment where an
+actor has stopped serving messages but is still discoverable.
+
+Real deployments are messier. An actor can accept its stop and then take time to
+drain a mailbox or tear down an external resource, staying registered but not
+serving for a while. Code that waits on deregistration has to tolerate that
+window, and the tolerance is hard to test when the window is zero-width by
+construction.
+
+`Receptionist::set_terminate_hook` opens it:
+
+```rust,ignore
+receptionist.set_terminate_hook(Some(Arc::new(my_hook)));  // None clears it
+```
+
+The hook is awaited between the supervisor exiting and the guard firing. While
+it is pending, `lookup` still finds the actor, listings still include it, and its
+watches have not fired. It returns a future rather than taking a duration, so
+under simulation you build the delay from the runtime seam and the window runs
+on virtual time, reproducible from the seed.
+
+It is a fault-injection seam. Do not do real work in it. It runs on the
+supervisor's task and holds the registry entry for as long as it stays pending,
+so a hook that never completes leaks the entry. It fires for every actor
+terminating on the node, including murmer's internal ones, so a hook aimed at one
+actor has to filter on the label it is handed. It does not fire on the
+restart-limit-exceeded path, where the receptionist deregisters directly instead
+of through a supervisor exit.
+
+See [Extending Simulation](./simulation-extending.md) for a worked example that
+holds one named actor in that state for five seconds of virtual time.
+
 ## Watching actors
 
 Any actor can monitor another actor for termination using `ctx.watch()`. When the watched actor terminates (for any reason), the watcher receives an `ActorTerminated` notification via `on_actor_terminated`.


### PR DESCRIPTION
## Why

#31 shipped the `TerminateHook` seam with thorough rustdoc and a section in `simulation-extending.md`. But that chapter is the Layer-3 handoff doc, aimed at someone building a disk-fault sim on top of murmer. The two places a reader would actually go had nothing.

Asked myself where I'd look if I were reading about actor termination and didn't already know the hook existed. Neither answer had it.

## What

**`supervision.md`** gets a "Deregistration on termination" subsection under "Interaction with the receptionist". That section covered the *restart* flow in detail but never the *termination* flow, so deregistration was undocumented even before this seam existed. The new text covers:

- the `DeregisterGuard` and why it makes the window zero-width in normal operation
- the hook that opens it, and what stays true while it is pending (`lookup` finds the actor, listings include it, watches have not fired)
- why it returns a future rather than taking a duration (so the delay comes from the runtime seam and runs on virtual time)
- the three limits worth knowing: it holds the registry entry while pending, it fires for *every* actor on the node including murmer's internal ones, and it does not fire on the restart-limit-exceeded path

**`simulation.md`** gets a short pointer in "What works under sim". That section enumerates local-path coverage, so someone auditing which faults they can inject would have come away thinking teardown had no seam.

Both link across to the worked example in `simulation-extending.md` rather than repeating it.

## Verification

`mdbook build book` clean, no warnings. Docs only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)