### PR TITLE
chore(release): bump workspace to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2022,7 +2022,7 @@ dependencies = [
 
 [[package]]
 name = "murmer"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "murmer-cluster-tests"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bincode",
  "iroh",
@@ -2063,7 +2063,7 @@ dependencies = [
 
 [[package]]
 name = "murmer-examples"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bincode",
  "iroh",
@@ -2077,7 +2077,7 @@ dependencies = [
 
 [[package]]
 name = "murmer-macros"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-murmer = { path = "murmer", version = "0.4.0" }
-murmer-macros = { path = "murmer-macros", version = "0.4.0" }
+murmer = { path = "murmer", version = "0.4.1" }
+murmer-macros = { path = "murmer-macros", version = "0.4.1" }
 bincode = { version = "2.0.1", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
@@ -21,7 +21,7 @@ metrics = "0.24"
 metrics-exporter-prometheus = "0.18"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 authors = ["Andrew Paxson"]
 keywords = ["actor", "distributed", "actor-model", "async"]

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Your Code → Endpoint<A> ──┤
 
 ```toml
 [dependencies]
-murmer = "0.3"
+murmer = "0.4"
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 ```

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -6,7 +6,7 @@ This chapter goes deeper into the components you saw in the [introduction](./int
 
 ```toml
 [dependencies]
-murmer = "0.3"
+murmer = "0.4"
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 ```

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -31,7 +31,7 @@ The design draws heavy inspiration from BEAM OTP's supervision and process model
 
 ```toml
 [dependencies]
-murmer = "0.3"
+murmer = "0.4"
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 ```

--- a/book/src/monitoring.md
+++ b/book/src/monitoring.md
@@ -8,7 +8,7 @@ Add the `monitor` feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-murmer = { version = "0.3", features = ["monitor"] }
+murmer = { version = "0.4", features = ["monitor"] }
 ```
 
 When the feature is **off**, all instrumentation compiles to nothing — zero overhead, zero dependencies.

--- a/book/src/murmer-app.md
+++ b/book/src/murmer-app.md
@@ -8,7 +8,7 @@ Enable the feature in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-murmer = { version = "0.3", features = ["app"] }
+murmer = { version = "0.4", features = ["app"] }
 ```
 
 ## Overview

--- a/book/src/simulation.md
+++ b/book/src/simulation.md
@@ -10,7 +10,7 @@ Enable the `sim` feature:
 
 ```toml
 [dev-dependencies]
-murmer = { version = "0.3", features = ["sim"] }
+murmer = { version = "0.4", features = ["sim"] }
 ```
 
 ## The idea


### PR DESCRIPTION
## Patch, not minor — and I checked rather than assumed

The public API delta since `v0.4.0` is exactly two additions, with nothing removed and nothing changed:

```
+pub trait TerminateHook
+pub fn Receptionist::set_terminate_hook
```

The part worth verifying was the dependency bumps, since a breaking bump of a *publicly exposed* dependency is a breaking change for downstream even when our own code is untouched. Checked each:

| Dependency | Bump | Public? |
|---|---|---|
| metrics-exporter-prometheus | 0.16 → 0.18 | No — used only inside a function body in `prometheus_setup.rs` |
| mdns-sd | 0.18 → 0.20 | No — internal to `discovery.rs` |
| syn | 2 → 3 | No — confined to `murmer-macros`, which exposes macros rather than syn types |
| **iroh** | 1.0.2 → 1.0.3 | **Yes** — `System::endpoint_id`/`endpoint_addr` return `iroh::EndpointId`/`EndpointAddr`. Patch-level only, so compatible. |

iroh was the one that could have forced a minor. It moved a patch, so it doesn't.

Everything else since 0.4.0 is internal: the biased `select!` change is behavioral with no signature change, and the rest are lockfile bumps.

So this is compatible for every downstream, which for a 0.x crate is exactly what the patch position signals to Cargo (`0.4.x` compatible, `0.5.0` breaking).

## Also fixes stale install docs

The README and five book chapters still said `murmer = "0.3"`. They were never updated when 0.4.0 shipped, so anyone following the getting-started instructions was pulling a release two versions behind. Now `"0.4"`.

## Verification

Ran the exact gates `release.yml` runs before it publishes:

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 239 passed
- `cargo publish -p murmer-macros --dry-run` — packages and verifies clean

`cargo publish -p murmer --dry-run` fails with `failed to select a version for the requirement murmer-macros = "^0.4.1"`. That is the expected workspace dry-run limitation, not a problem: macros isn't on crates.io at 0.4.1 yet, and the workflow publishes `murmer-macros` before `murmer`. Both crates are present on crates.io at 0.4.0, so that ordering is proven to work.

## Not tagged

Deliberately stopping here. Pushing a `v0.4.1` tag triggers `release.yml`, which publishes to crates.io, and crates.io versions can be yanked but never deleted. Merge this first, then tag when you want the release to go out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)