### PR TITLE
chore(release): bump workspace to 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,7 +805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1089,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1892,9 +1892,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.1"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+checksum = "ff9840bcc50b71349309900da0ce7279aa336ae71d73250b07998932c7d97c25"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -3069,7 +3069,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3162,7 +3162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4096,7 +4096,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,7 +394,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -969,7 +969,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2022,7 +2022,7 @@ dependencies = [
 
 [[package]]
 name = "murmer"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "murmer-cluster-tests"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bincode",
  "iroh",
@@ -2063,7 +2063,7 @@ dependencies = [
 
 [[package]]
 name = "murmer-examples"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bincode",
  "iroh",
@@ -2077,7 +2077,7 @@ dependencies = [
 
 [[package]]
 name = "murmer-macros"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-murmer = { path = "murmer", version = "0.4.1" }
-murmer-macros = { path = "murmer-macros", version = "0.4.1" }
+murmer = { path = "murmer", version = "0.4.2" }
+murmer-macros = { path = "murmer-macros", version = "0.4.2" }
 bincode = { version = "2.0.1", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
@@ -21,7 +21,7 @@ metrics = "0.24"
 metrics-exporter-prometheus = "0.18"
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 authors = ["Andrew Paxson"]
 keywords = ["actor", "distributed", "actor-model", "async"]

--- a/murmer/src/sim.rs
+++ b/murmer/src/sim.rs
@@ -520,7 +520,7 @@ impl SimWorld {
     fn drain_inbox(&mut self) {
         let futs: Vec<BoxFuture<'static, ()>> = {
             let mut s = self.runtime.shared.lock().unwrap();
-            s.inbox.drain(..).collect()
+            std::mem::take(&mut s.inbox)
         };
         for fut in futs {
             // The inbox holds `Send` futures (`BoxFuture`); the executor stores


### PR DESCRIPTION
## Summary

Patch release. Public API is unchanged from 0.4.1; this ships the dependency bumps that landed on main since then, closes the one real advisory in the tree, and gets main's CI green again.

### Commits

- **fix(sim): use `mem::take` in `drain_inbox`** — stable Rust 1.98 promoted `clippy::drain_collect` into the default set, and the `-D warnings` job has rejected `murmer/src/sim.rs` on every push since Sept 4. Same semantics, no intermediate allocation. This is what unblocks the release workflow, whose publish step gates on Clippy.
- **chore(deps): bump h2 → 0.4.19, lru → 0.18.4** — closes RUSTSEC-2026-0258 (h2, unbounded empty DATA frames) and RUSTSEC-2026-0253 (lru, panic-safety UAF in `pop()`). Both transitive, lockfile only. Dependabot never opened a PR for either because the cargo config only tracks direct deps.
- **chore(deps): fix stale `syn 3.0.3` references in Cargo.lock** — the clap and syn dependabot PRs were rebase-merged independently, leaving two dependency lists naming a package entry that no longer exists. Cargo repairs it silently on resolve, but `--locked` would reject it.
- **chore(release): bump workspace to 0.4.2** — see the commit message for the patch-vs-minor reasoning; short version: foca 1.0 and mdns-sd 0.21 are internal, iroh 1.1.0 is in the public API but semver-minor, everything else is a patch bump.

### Validation

- `cargo clippy --workspace --all-targets -- -D warnings` and the `sim,app` variant: clean
- `cargo check` on both feature sets: clean
- `cargo audit`: 0 vulnerabilities (remaining warnings are the pre-existing bincode/paste unmaintained and chacha20 yanked notices)
- `cargo publish -p murmer-macros --dry-run`: packages clean

### After merge

Tag the merge commit `v0.4.2` to trigger the Release workflow and publish `murmer-macros` then `murmer` to crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYVbpvgTqpLYJcY6N7cv5U

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYVbpvgTqpLYJcY6N7cv5U)_